### PR TITLE
fix: Set root UI path when behind proxy

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -116,7 +116,11 @@ if WITH_UI:
     tmp_output_dir = Path(tempfile.mkdtemp())
     gradio_ui.gradio_output_dir = tmp_output_dir
     app = gr.mount_gradio_app(
-        app, gradio_ui, path="/ui", allowed_paths=["./logo.png", tmp_output_dir], root_path="/ui"
+        app,
+        gradio_ui,
+        path="/ui",
+        allowed_paths=["./logo.png", tmp_output_dir],
+        root_path="/ui",
     )
 
 


### PR DESCRIPTION
There was one parameter missing in the Gradio  config to make it work properly behind a proxy, like the HAProxy router in an OpenShift Route.