### PR TITLE
fix: Build arm64 image for docling-serve (gpu)

### DIFF
--- a/.github/workflows/ci-images-dryrun.yml
+++ b/.github/workflows/ci-images-dryrun.yml
@@ -38,6 +38,5 @@ jobs:
       publish: false
       build_args: |
         UV_SYNC_EXTRA_ARGS=--no-extra cpu
-      platforms: linux/amd64
       ghcr_image_name: ds4sd/docling-serve
       quay_image_name: ""

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,14 +7,6 @@ on:
   release:
     types: [published]
 
-# env:
-#   GHCR_REGISTRY: ghcr.io
-#   # GHCR_DOCLING_SERVE_CPU_IMAGE_NAME: ds4sd/docling-serve-cpu
-#   # GHCR_DOCLING_SERVE_GPU_IMAGE_NAME: ds4sd/docling-serve
-#   QUAY_REGISTRY: quay.io
-#   # QUAY_DOCLING_SERVE_CPU_IMAGE_NAME: ds4sd/docling-serve-cpu
-#   # QUAY_DOCLING_SERVE_GPU_IMAGE_NAME: ds4sd/docling-serve
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -54,7 +46,6 @@ jobs:
       environment: registry-creds
       build_args: |
         UV_SYNC_EXTRA_ARGS=--no-extra cpu
-      platforms: linux/amd64
       ghcr_image_name: ds4sd/docling-serve
       quay_image_name: ds4sd/docling-serve
 

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -28,11 +28,7 @@ on:
 
 env:
   GHCR_REGISTRY: ghcr.io
-  # GHCR_DOCLING_SERVE_CPU_IMAGE_NAME: ds4sd/docling-serve-cpu
-  # GHCR_DOCLING_SERVE_GPU_IMAGE_NAME: ds4sd/docling-serve
   QUAY_REGISTRY: quay.io
-  # QUAY_DOCLING_SERVE_CPU_IMAGE_NAME: ds4sd/docling-serve-cpu
-  # QUAY_DOCLING_SERVE_GPU_IMAGE_NAME: ds4sd/docling-serve
 
 jobs:
   image:

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -6,3 +6,6 @@ config:
     allowed_elements: ["details", "summary"]
 globs:
   - "**/*.md"
+ignores:
+  - ".venv"
+

--- a/README.md
+++ b/README.md
@@ -338,43 +338,41 @@ See `[project.optional-dependencies]` section in `pyproject.toml` for full list 
 
 ### Run the server
 
-The `docling-serve` executable is a convenient script for launching the webserver both in
-development and production mode.
+UV will generate the virtual environment and place all the binaries in `.venv/bin`. Use the following commands to run the docling-serve
 
 ```sh
 # Run the server in development mode
 # - reload is enabled by default
 # - listening on the 127.0.0.1 address
 # - ui is enabled by default
-docling-serve dev
+uv run docling-serve dev
 
 # Run the server in production mode
 # - reload is disabled by default
 # - listening on the 0.0.0.0 address
 # - ui is disabled by default
-docling-serve run
+uv run docling-serve run
 ```
 
 ### Options
 
-The `docling-serve` executable allows is controlled with both command line
-options and environment variables.
+`docling-serve` supports both command line options and environment variables to configure the docling-serve.
 
 <details>
 <summary>`docling-serve` help message</summary>
 
 ```sh
 $ docling-serve dev --help
-                                                                                                              
- Usage: docling-serve dev [OPTIONS]                                                                           
-                                                                                                              
- Run a Docling Serve app in development mode. 🧪                                                              
- This is equivalent to docling-serve run but with reload                                                      
- enabled and listening on the 127.0.0.1 address.                                                              
-                                                                                                              
- Options can be set also with the corresponding ENV variable, with the exception                              
- of --enable-ui, --host and --reload.                                                                         
-                                                                                                              
+
+ Usage: docling-serve dev [OPTIONS]
+
+ Run a Docling Serve app in development mode. 🧪
+ This is equivalent to docling-serve run but with reload
+ enabled and listening on the 127.0.0.1 address.
+
+ Options can be set also with the corresponding ENV variable, with the exception
+ of --enable-ui, --host and --reload.
+
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ --host                                   TEXT     The host to serve on. For local development in localhost │
 │                                                   use 127.0.0.1. To enable public access, e.g. in a        │


### PR DESCRIPTION
Also fixes the README docling-serve execution instructions.