### PR TITLE
fix: allow changes in CORS settings

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -135,9 +135,9 @@ def create_app():  # noqa: C901
         version=version,
     )
 
-    origins = ["*"]
-    methods = ["*"]
-    headers = ["*"]
+    origins = docling_serve_settings.cors_origins
+    methods = docling_serve_settings.cors_methods
+    headers = docling_serve_settings.cors_headers
 
     app.add_middleware(
         CORSMiddleware,

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -30,6 +30,10 @@ class DoclingServeSettings(BaseSettings):
     enable_ui: bool = False
     artifacts_path: Optional[Path] = None
 
+    cors_origins: list[str] = ["*"]
+    cors_methods: list[str] = ["*"]
+    cors_headers: list[str] = ["*"]
+
     eng_kind: AsyncEngine = AsyncEngine.LOCAL
     eng_loc_num_workers: int = 2
 


### PR DESCRIPTION
Expose CORS parameters as ENV variables, e.g.

```
DOCLING_SERVE_CORS_ORIGINS='["localhost"]' docling-serve run
```

Because of what was found in #99, it is better to expose the parameter only as ENV.

**Issue resolved by this Pull Request:**
Resolves #88
