### PR TITLE
fix: avoid exploding options cache using lru and expose size parameter

### DIFF
--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -29,6 +29,7 @@ class DoclingServeSettings(BaseSettings):
 
     enable_ui: bool = False
     artifacts_path: Optional[Path] = None
+    options_cache_size: int = 2
 
     eng_kind: AsyncEngine = AsyncEngine.LOCAL
     eng_loc_num_workers: int = 2


### PR DESCRIPTION
Switching from an infinite cache to LRU controlled by the parameter `DOCLING_SERVE_OPTIONS_CACHE_SIZE` (default 2).

**Issue resolved by this Pull Request:**
Resolves #86

