### PR TITLE
feat: Offline static files

### DIFF
--- a/docling_serve/gradio_ui.py
+++ b/docling_serve/gradio_ui.py
@@ -23,8 +23,7 @@ if (
     and docling_serve_settings.static_path.is_dir()
 ):
     logo_path = str(docling_serve_settings.static_path / "logo.svg")
-    js_components_url = "https://unpkg.com/@docling/docling-components@0.0.3"
-    # js_components_url = "/static/docling-components.js"
+    js_components_url = "/static/docling-components.js"
 
 
 ##############################

--- a/docling_serve/gradio_ui.py
+++ b/docling_serve/gradio_ui.py
@@ -8,15 +8,30 @@ import gradio as gr
 import requests
 
 from docling_serve.helper_functions import _to_list_of_strings
-from docling_serve.settings import uvicorn_settings
+from docling_serve.settings import docling_serve_settings, uvicorn_settings
 
 logger = logging.getLogger(__name__)
+
+############################
+# Path of static artifacts #
+############################
+
+logo_path = "https://raw.githubusercontent.com/docling-project/docling/refs/heads/main/docs/assets/logo.svg"
+js_components_url = "https://unpkg.com/@docling/docling-components@0.0.3"
+if (
+    docling_serve_settings.static_path is not None
+    and docling_serve_settings.static_path.is_dir()
+):
+    logo_path = str(docling_serve_settings.static_path / "logo.svg")
+    js_components_url = "https://unpkg.com/@docling/docling-components@0.0.3"
+    # js_components_url = "/static/docling-components.js"
+
 
 ##############################
 # Head JS for web components #
 ##############################
-head = """
-    <script src="https://unpkg.com/@docling/docling-components@0.0.3" type="module"></script>
+head = f"""
+    <script src="{js_components_url}" type="module"></script>
 """
 
 #################
@@ -360,7 +375,7 @@ with gr.Blocks(
         with gr.Column(scale=1, min_width=90):
             try:
                 gr.Image(
-                    "https://raw.githubusercontent.com/docling-project/docling/refs/heads/main/docs/assets/logo.svg",
+                    logo_path,
                     height=80,
                     width=80,
                     show_download_button=False,

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -30,6 +30,7 @@ class DoclingServeSettings(BaseSettings):
 
     enable_ui: bool = False
     artifacts_path: Optional[Path] = None
+    static_path: Optional[Path] = None
     options_cache_size: int = 2
     allow_external_plugins: bool = False
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ THe following table describes the options to configure the Docling Serve app.
 | CLI option | ENV | Default | Description |
 | -----------|-----|---------|-------------|
 | `--artifacts-path` | `DOCLING_SERVE_ARTIFACTS_PATH` | unset | If set to a valid directory, the model weights will be loaded from this path |
+|  | `DOCLING_SERVE_STATIC_PATH` | unset | If set to a valid directory, the static assets for the docs and ui will be loaded from this path |
 | `--enable-ui` | `DOCLING_SERVE_ENABLE_UI` | `false` | Enable the demonstrator UI. |
 |  | `DOCLING_SERVE_OPTIONS_CACHE_SIZE` | `2` | How many DocumentConveter objects (including their loaded models) to keep in the cache. |
 |  | `DOCLING_SERVE_CORS_ORIGINS` | `["*"]` | A list of origins that should be permitted to make cross-origin requests. |


### PR DESCRIPTION
The new option `DOCLING_SERVE_STATIC_PATH` allows to run the Swagger UI and the Gradio UI completely offline.

Example on how to get the static files:

```sh
# Make the folder static
mkdir -p ~/.cache/docling/static
cd ~/.cache/docling/static

# Download static files
curl -LO https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js
curl -LO https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css
curl -LO https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js
curl -o docling-components.js https://unpkg.com/@docling/docling-components@0.0.3/dist/index.js
```


<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
