### PR TITLE
fix: Fix image permissions to run it with any-user-id on Openshift

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -52,8 +52,8 @@ RUN echo "Downloading models..." && \
     HF_HUB_DOWNLOAD_TIMEOUT="90" \
     HF_HUB_ETAG_TIMEOUT="90" \
     docling-tools models download -o "${DOCLING_SERVE_ARTIFACTS_PATH}" ${MODELS_LIST} && \
-    chown -R 1001:0 /opt/app-root/src/.cache && \
-    chmod -R g=u /opt/app-root/src/.cache
+    chgrp -R 0 /opt/app-root/ && \
+    chmod -R g=u /opt/app-root/
 
 COPY --chown=1001:0 ./docling_serve ./docling_serve
 RUN --mount=from=ghcr.io/astral-sh/uv:0.6.1,source=/uv,target=/bin/uv \
@@ -61,9 +61,6 @@ RUN --mount=from=ghcr.io/astral-sh/uv:0.6.1,source=/uv,target=/bin/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-dev --all-extras ${UV_SYNC_EXTRA_ARGS}
-
-RUN chgrp -R 0 /opt/app-root/ && \
-    chmod -R g=u /opt/app-root/
 
 EXPOSE 5001
 

--- a/Containerfile
+++ b/Containerfile
@@ -63,9 +63,7 @@ RUN --mount=from=ghcr.io/astral-sh/uv:0.6.1,source=/uv,target=/bin/uv \
     uv sync --frozen --no-dev --all-extras ${UV_SYNC_EXTRA_ARGS}
 
 RUN chgrp -R 0 /opt/app-root/ && \
-    chmod -R g=u /opt/app-root/ && \
-    chgrp -R 0 ./docling_serve && \
-    chmod -R g=u ./docling_serve
+    chmod -R g=u /opt/app-root/
 
 EXPOSE 5001
 

--- a/Containerfile
+++ b/Containerfile
@@ -62,6 +62,11 @@ RUN --mount=from=ghcr.io/astral-sh/uv:0.6.1,source=/uv,target=/bin/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-dev --all-extras ${UV_SYNC_EXTRA_ARGS}
 
+RUN chgrp -R 0 /opt/app-root/ && \
+    chmod -R g=u /opt/app-root/ && \
+    chgrp -R 0 ./docling_serve && \
+    chmod -R g=u ./docling_serve
+
 EXPOSE 5001
 
 CMD ["docling-serve", "run"]


### PR DESCRIPTION
Fixes access to `/opt/app-root/` for any-user-id that is used by Openshift. This allows to install additional packages into image, for example in case of kubeflow pipelines.

**Issue resolved by this Pull Request:**
Resolves #118 
