### PR TITLE
feat(UI): change UI to use async endpoints

### DIFF
--- a/docling_serve/gradio_ui.py
+++ b/docling_serve/gradio_ui.py
@@ -378,7 +378,6 @@ def process_file(
         ssl_ctx = get_ssl_context()
         response = httpx.post(
             f"{get_api_endpoint()}/v1alpha/convert/source/async",
-            files=files_data,
             json=parameters,
             verify=ssl_ctx,
             timeout=60,


### PR DESCRIPTION
UI use async endpoints:

- [x] `task_id` is shown in UI after task is send to queue
- [x] disable output as file as currently async endpoints does not output as file
- [x] rename to accept single file/url
- [x] upload file is converted to base64 string before sending to conversion