### PR TITLE
fix: usage of hashlib for FIPS

### DIFF
--- a/docling_serve/docling_conversion.py
+++ b/docling_serve/docling_conversion.py
@@ -58,7 +58,9 @@ def _hash_pdf_format_option(pdf_format_option: PdfFormatOption) -> bytes:
 
     # Serialize the dictionary to JSON with sorted keys to have consistent hashes
     serialized_data = json.dumps(data, sort_keys=True)
-    options_hash = hashlib.sha1(serialized_data.encode()).digest()
+    options_hash = hashlib.sha1(
+        serialized_data.encode(), usedforsecurity=False
+    ).digest()
     return options_hash
 
 


### PR DESCRIPTION
Since we don't rely on hashes for credentials and security, we should use the option `usedforsecurity=False` to facilitate FIPS use cases.

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
