### PR TITLE
docs: add openshift replicasets examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -444,3 +444,5 @@ pip-selfcheck.json
 # Makefile
 .action-lint
 .markdown-lint
+
+cookies.txt

--- a/docs/deploy-examples/docling-serve-replicas-w-sticky-sessions.yaml
+++ b/docs/deploy-examples/docling-serve-replicas-w-sticky-sessions.yaml
@@ -1,4 +1,4 @@
-# This example deployment configures Docling Serve with a Route + Sticky sessions, a Service and cuda image
+# This example deployment configures Docling Serve with a Route + Sticky sessions, a Service and cpu image
 ---
 kind: Route
 apiVersion: route.openshift.io/v1

--- a/docs/deploy-examples/docling-serve-replicas-w-sticky-sessions.yaml
+++ b/docs/deploy-examples/docling-serve-replicas-w-sticky-sessions.yaml
@@ -8,9 +8,8 @@ metadata:
     app: docling-serve
     component: docling-serve-api
   annotations:
-    haproxy.router.openshift.io/disable_cookies: "false"
+    haproxy.router.openshift.io/disable_cookies: "false" # this annotation enables the sticky sessions
 spec:
-  host: '${MY_HOSTNAME}'
   path: /
   to:
     kind: Service
@@ -63,11 +62,9 @@ spec:
             limits:
               cpu: 500m
               memory: 2Gi
-              nvidia.com/gpu: 1  # Limit to one GPU
             requests:
               cpu: 250m
               memory: 1Gi
-              nvidia.com/gpu: 1  # Limit to one GPU
           env:
             - name: DOCLING_SERVE_ENABLE_UI
               value: 'true'
@@ -76,4 +73,4 @@ spec:
               containerPort: 5001
               protocol: TCP
           imagePullPolicy: Always
-          image: 'ghcr.io/docling-project/docling-serve-cu124'
+          image: 'ghcr.io/docling-project/docling-serve'

--- a/docs/deploy-examples/docling-serve-replicas-w-sticky-sessions.yaml
+++ b/docs/deploy-examples/docling-serve-replicas-w-sticky-sessions.yaml
@@ -1,0 +1,79 @@
+# This example deployment configures Docling Serve with a Route + Sticky sessions, a Service and cuda image
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: docling-serve
+  labels:
+    app: docling-serve
+    component: docling-serve-api
+  annotations:
+    haproxy.router.openshift.io/disable_cookies: "false"
+spec:
+  host: '${MY_HOSTNAME}'
+  path: /
+  to:
+    kind: Service
+    name: docling-serve
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: docling-serve
+  labels:
+    app: docling-serve
+    component: docling-serve-api
+spec:
+  ports:
+  - name: http
+    port: 5001
+    targetPort: http
+  selector:
+    app: docling-serve
+    component: docling-serve-api
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: docling-serve
+  labels:
+    app: docling-serve
+    component: docling-serve-api
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: docling-serve
+      component: docling-serve-api
+  template:
+    metadata:
+      labels:
+        app: docling-serve
+        component: docling-serve-api
+    spec:
+      restartPolicy: Always
+      containers:
+        - name: api
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2Gi
+              nvidia.com/gpu: 1  # Limit to one GPU
+            requests:
+              cpu: 250m
+              memory: 1Gi
+              nvidia.com/gpu: 1  # Limit to one GPU
+          env:
+            - name: DOCLING_SERVE_ENABLE_UI
+              value: 'true'
+          ports:
+            - name: http
+              containerPort: 5001
+              protocol: TCP
+          imagePullPolicy: Always
+          image: 'ghcr.io/docling-project/docling-serve-cu124'

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -202,19 +202,23 @@ This deployment has the following features:
 - Deployment configuration with 3 replicas
 - Service configuration
 - Expose the service using a OpenShift `Route` and enables sticky sessions
-- NVIDIA cuda enabled
 
 Install the app with:
 
 ```sh
-export MY_HOSTNAME="docling-serve.your-cluster.example.com"
-envsubst < docs/deploy-examples/docling-serve-replicas-w-sticky-sessions.yaml | oc apply -f -
+oc apply -f docs/deploy-examples/docling-serve-replicas-w-sticky-sessions.yaml
 ```
 
+For using the API:
+
 ```sh
+# Retrieve the endpoint
+DOCLING_NAME=docling-serve
+DOCLING_ROUTE="https://$(oc get routes $DOCLING_NAME --template={{.spec.host}})"
+
 # Make a test query, store the cookie and taskid
 task_id=$(curl -s -X 'POST' \
-    "https://$MY_HOSTNAME/v1alpha/convert/source/async" \
+    "${DOCLING_ROUTE}/v1alpha/convert/source/async" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
     -d '{
@@ -226,7 +230,7 @@ task_id=$(curl -s -X 'POST' \
 ```sh
 # Grab the taskid and cookie to check the task status
 curl -v -X 'GET' \
-  "https://$MY_HOSTNAME/v1alpha/status/poll/$task_id?wait=0" \
+  "${DOCLING_ROUTE}/v1alpha/status/poll/$task_id?wait=0" \
   -H "accept: application/json" \
   -b "cookies.txt"
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -199,7 +199,7 @@ Manifest example: [docling-serve-replicas-w-sticky-sessions.yaml](./deploy-examp
 
 This deployment has the following features:
 
-- Deployment configuration
+- Deployment configuration with 3 replicas
 - Service configuration
 - Expose the service using a OpenShift `Route` and enables sticky sessions
 - NVIDIA cuda enabled


### PR DESCRIPTION
- adds openshift replicasets with sticky sessions examples
