### PR TITLE
feat: Read supported file extensions from docling

### DIFF
--- a/docling_serve/gradio_ui.py
+++ b/docling_serve/gradio_ui.py
@@ -1,5 +1,6 @@
 import base64
 import importlib
+import itertools
 import json
 import logging
 import ssl
@@ -12,6 +13,7 @@ import certifi
 import gradio as gr
 import httpx
 
+from docling.datamodel.base_models import FormatToExtensions
 from docling.datamodel.pipeline_options import (
     PdfBackend,
     PdfPipeline,
@@ -545,19 +547,10 @@ with gr.Blocks(
                     elem_id="file_input_zone",
                     label="Upload File",
                     file_types=[
-                        ".pdf",
-                        ".docx",
-                        ".pptx",
-                        ".html",
-                        ".xlsx",
-                        ".json",
-                        ".asciidoc",
-                        ".txt",
-                        ".md",
-                        ".jpg",
-                        ".jpeg",
-                        ".png",
-                        ".gif",
+                        f".{v}"
+                        for v in itertools.chain.from_iterable(
+                            FormatToExtensions.values()
+                        )
                     ],
                     file_count="multiple",
                     scale=4,


### PR DESCRIPTION
This is a step for supporting WEBP format.

I think https://github.com/docling-project/docling/pull/1415 missed adding `webp` to `FormatToMimeType`.
I will send a PR for docling repo and link it here.