### PR TITLE
feat: Enable providing pre-signed PUT-able URL for remote result file storage

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -5,7 +5,7 @@ import shutil
 import time
 from contextlib import asynccontextmanager
 from io import BytesIO
-from typing import Annotated
+from typing import Annotated, Union
 
 from fastapi import (
     BackgroundTasks,
@@ -43,6 +43,7 @@ from docling_serve.datamodel.responses import (
     ConvertDocumentResponse,
     HealthCheckResponse,
     MessageKind,
+    RemoteFileResponse,
     TaskStatusResponse,
     WebsocketMessage,
 )
@@ -505,12 +506,15 @@ def create_app():  # noqa: C901
     # Task result
     @app.get(
         "/v1alpha/result/{task_id}",
-        response_model=ConvertDocumentResponse,
+        response_model=Union[ConvertDocumentResponse, RemoteFileResponse],
         responses={
             200: {
-                "content": {"application/zip": {}},
+                "content": {
+                    "application/zip": {},
+                    "application/json": {},
+                }
             }
-        },
+        }
     )
     async def task_result(
         orchestrator: Annotated[BaseAsyncOrchestrator, Depends(get_async_orchestrator)],

--- a/docling_serve/datamodel/convert.py
+++ b/docling_serve/datamodel/convert.py
@@ -266,6 +266,19 @@ class ConvertDocumentsOptions(BaseModel):
         ),
     ] = False
 
+    remote_storage_url: Annotated[
+        Optional[AnyUrl],
+        Field(
+            description=(
+                "If set, the output will be stored in the cloud storage. "
+                "The URL should point to a PUT-able, pre-signed cloud storage URL (e.g. GCS, S3 pre-signed URL)."
+            ),
+            examples=[
+                AnyUrl("https://example.com/upload?key=value"),
+            ],
+        ),
+    ] = None
+
     do_table_structure: Annotated[
         bool,
         Field(
@@ -390,5 +403,13 @@ class ConvertDocumentsOptions(BaseModel):
             raise ValueError(
                 "The parameters picture_description_local and picture_description_api are mutually exclusive, only one of them can be set."
             )
+
+        return self
+
+    @model_validator(mode="after")
+    def force_file_if_upload_result(self) -> Self:
+        # If cloud storage URL is set, force return_as_file to True
+        if self.remote_storage_url is not None:
+            self.return_as_file = True
 
         return self

--- a/docling_serve/datamodel/responses.py
+++ b/docling_serve/datamodel/responses.py
@@ -1,7 +1,7 @@
 import enum
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, AnyUrl
 
 from docling.datamodel.document import ConversionStatus, ErrorItem
 from docling.utils.profiling import ProfilingItem
@@ -35,6 +35,8 @@ class ConvertDocumentResponse(BaseModel):
     processing_time: float
     timings: dict[str, ProfilingItem] = {}
 
+class RemoteFileResponse(BaseModel):
+    url: AnyUrl
 
 class ConvertDocumentErrorResponse(BaseModel):
     status: ConversionStatus

--- a/docling_serve/engines/async_local/worker.py
+++ b/docling_serve/engines/async_local/worker.py
@@ -10,6 +10,7 @@ from docling.datamodel.base_models import DocumentStream
 
 from docling_serve.datamodel.engines import TaskStatus
 from docling_serve.datamodel.requests import FileSource, HttpSource
+from docling_serve.datamodel.responses import RemoteFileResponse
 from docling_serve.docling_conversion import convert_documents
 from docling_serve.response_preparation import process_results
 from docling_serve.storage import get_scratch
@@ -77,7 +78,7 @@ class AsyncLocalWorker:
 
                     if work_dir.exists():
                         task.scratch_dir = work_dir
-                        if not isinstance(response, FileResponse):
+                        if not (isinstance(response, FileResponse) or isinstance(response, RemoteFileResponse)):
                             _log.warning(
                                 f"Task {task_id=} produced content in {work_dir=} but the response is not a file."
                             )


### PR DESCRIPTION
When hosting docling-serve behind an AWS gateway, there's a hard limit for both request **and response** payloads of 10Mbyte.

Docling's remote fetch is suitable for uploading large docs, however when producing large results (esp json format), the AWS limit gets in the way for any reasonably image-heavy sources.

The simplest way around this is to bounce the result via an S3 or GCS storage bucket, both of which permit the creation of pre-signed, PUT-able URLs for result upload.  Benefit of this approach is that no keys or secrets are required to be available on the docling server - the caller just generates a pre-signed URL and passes it with the request, then fetches the result upon completion.

The proposed patch:
* Adds `remote_storage_url` option to `ConvertDocumentsOptions`.
* Upload conversion result to `remote_storage_url` if provided (via "PUT" method)
* Return `RemoteFileResponse` with URL upon successful upload.
* Force `return_as_file` to true if `remote_storage_url` is active.