### PR TITLE
fix: Typo in Headline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Dolcing Serve documentation
+# Docling Serve documentation
 
 This documentation pages explore the webserver configurations, runtime options, deployment examples as well as development best practices.
 


### PR DESCRIPTION
Changed Dolcing to Docling

Description:
Just fixed a small typo in the headline of the docs
