### PR TITLE
fix: missing tesseract osd

### DIFF
--- a/os-packages.txt
+++ b/os-packages.txt
@@ -1,6 +1,7 @@
 tesseract
 tesseract-devel
 tesseract-langpack-eng
+tesseract-osd
 leptonica-devel
 libglvnd-glx
 glib2


### PR DESCRIPTION
On RHEL and Fedora the tesseract installation needs an additional package:

dnf install tesseract tesseract-devel tesseract-langpack-eng **tesseract-osd** leptonica-devel 

**tesseract-osd** was missing.


**Issue resolved by this Pull Request:**
Resolves https://github.com/docling-project/docling/issues/1751 
