### PR TITLE
ci: workflow improvements

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -3,32 +3,68 @@
 set -e  # trigger failure on error - do not remove!
 set -x  # display command on output
 
+## debug
+# TARGET_VERSION="1.2.x"
+
 if [ -z "${TARGET_VERSION}" ]; then
     >&2 echo "No TARGET_VERSION specified"
     exit 1
 fi
 CHGLOG_FILE="${CHGLOG_FILE:-CHANGELOG.md}"
 
-# update package version
+# Update package version
 uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version "${TARGET_VERSION}"
 uv lock --upgrade-package docling-serve
 
-# collect release notes
+# Extract all docling packages and versions from uv.lock
+DOCVERSIONS=$(uvx --with toml python3 - <<'PY'
+import toml
+data = toml.load("uv.lock")
+for pkg in data.get("package", []):
+    if pkg["name"].startswith("docling"):
+        print(f"{pkg['name']} {pkg['version']}")
+PY
+)
+
+# Format docling versions list without trailing newline
+DOCLING_VERSIONS="### Docling libraries included in this release:"
+while IFS= read -r line; do
+  DOCLING_VERSIONS+="
+- $line"
+done <<< "$DOCVERSIONS"
+
+# Collect release notes
 REL_NOTES=$(mktemp)
 uv run --no-sync semantic-release changelog --unreleased >> "${REL_NOTES}"
 
-# update changelog
+# Strip trailing blank lines from release notes and append docling versions
+{
+  sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba' "${REL_NOTES}"
+  printf "\n"
+  printf "%s" "${DOCLING_VERSIONS}"
+  printf "\n"
+} > "${REL_NOTES}.tmp" && mv "${REL_NOTES}.tmp" "${REL_NOTES}"
+
+# Update changelog
 TMP_CHGLOG=$(mktemp)
 TARGET_TAG_NAME="v${TARGET_VERSION}"
 RELEASE_URL="$(gh repo view --json url -q ".url")/releases/tag/${TARGET_TAG_NAME}"
-printf "## [${TARGET_TAG_NAME}](${RELEASE_URL}) - $(date -Idate)\n\n" >> "${TMP_CHGLOG}"
-cat "${REL_NOTES}" >> "${TMP_CHGLOG}"
-if [ -f "${CHGLOG_FILE}" ]; then
-    printf "\n" | cat - "${CHGLOG_FILE}" >> "${TMP_CHGLOG}"
-fi
+## debug
+#RELEASE_URL="myrepo/releases/tag/${TARGET_TAG_NAME}"
+
+# Strip leading blank lines from existing changelog to avoid multiple blank lines when appending
+EXISTING_CL=$(sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba' "${CHGLOG_FILE}")
+
+{
+  printf "## [${TARGET_TAG_NAME}](${RELEASE_URL}) - $(date -Idate)\n\n"
+  cat "${REL_NOTES}"
+  printf "\n"
+  printf "%s\n" "${EXISTING_CL}"
+} >> "${TMP_CHGLOG}"
+
 mv "${TMP_CHGLOG}" "${CHGLOG_FILE}"
 
-# push changes
+# Push changes
 git config --global user.name 'github-actions[bot]'
 git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 git add pyproject.toml uv.lock "${CHGLOG_FILE}"
@@ -36,5 +72,5 @@ COMMIT_MSG="chore: bump version to ${TARGET_VERSION} [skip ci]"
 git commit -m "${COMMIT_MSG}"
 git push origin main
 
-# create GitHub release (incl. Git tag)
+# Create GitHub release (incl. Git tag)
 gh release create "${TARGET_TAG_NAME}" -F "${REL_NOTES}"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,7 +13,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       TARGET_TAG_V: ${{ steps.version_check.outputs.TRGT_VERSION }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # for fetching tags, required for semantic-release
       - name: Install uv and set the python version
@@ -40,7 +40,7 @@ jobs:
         with:
           app-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0  # for fetching tags, required for semantic-release

--- a/.github/workflows/job-build.yml
+++ b/.github/workflows/job-build.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         python-version: ['3.12']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/job-checks.yml
+++ b/.github/workflows/job-checks.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         python-version: ['3.12']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@v6
         with:
@@ -61,7 +61,7 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: markdownlint-cli2-action
         uses: DavidAnson/markdownlint-cli2-action@v16
         with:

--- a/.github/workflows/job-checks.yml
+++ b/.github/workflows/job-checks.yml
@@ -33,38 +33,36 @@ jobs:
   build-package:
     uses: ./.github/workflows/job-build.yml
 
-  # ## moved tests to .github/workflows/job-image.yml
-  
-  # test-package:
-  #   needs:
-  #     - build-package
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       python-version: ['3.12']
-  #   steps:
-  #     - name: Download all the dists
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: python-package-distributions
-  #         path: dist/
-  #     - name: Install uv and set the python version
-  #       uses: astral-sh/setup-uv@v6
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #         enable-cache: true
-  #     - name: Create virtual environment
-  #       run: uv venv
-  #     - name: Install package
-  #       run: uv pip install dist/*.whl
-  #     - name: Create the server
-  #       run: .venv/bin/python -c 'from docling_serve.app import create_app; create_app()'
+  test-package:
+    needs:
+      - build-package
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.12']
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+      - name: Create virtual environment
+        run: uv venv
+      - name: Install package
+        run: uv pip install dist/*.whl
+      - name: Create the server
+        run: .venv/bin/python -c 'from docling_serve.app import create_app; create_app()'
 
-  # markdown-lint:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v5
-  #     - name: markdownlint-cli2-action
-  #       uses: DavidAnson/markdownlint-cli2-action@v16
-  #       with:
-  #         globs: "**/*.md"
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: markdownlint-cli2-action
+        uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          globs: "**/*.md"

--- a/.github/workflows/job-checks.yml
+++ b/.github/workflows/job-checks.yml
@@ -33,36 +33,38 @@ jobs:
   build-package:
     uses: ./.github/workflows/job-build.yml
 
-  test-package:
-    needs:
-      - build-package
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.12']
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-          enable-cache: true
-      - name: Create virtual environment
-        run: uv venv
-      - name: Install package
-        run: uv pip install dist/*.whl
-      - name: Create the server
-        run: .venv/bin/python -c 'from docling_serve.app import create_app; create_app()'
+  # ## moved tests to .github/workflows/job-image.yml
+  
+  # test-package:
+  #   needs:
+  #     - build-package
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       python-version: ['3.12']
+  #   steps:
+  #     - name: Download all the dists
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: python-package-distributions
+  #         path: dist/
+  #     - name: Install uv and set the python version
+  #       uses: astral-sh/setup-uv@v6
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #         enable-cache: true
+  #     - name: Create virtual environment
+  #       run: uv venv
+  #     - name: Install package
+  #       run: uv pip install dist/*.whl
+  #     - name: Create the server
+  #       run: .venv/bin/python -c 'from docling_serve.app import create_app; create_app()'
 
-  markdown-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: markdownlint-cli2-action
-        uses: DavidAnson/markdownlint-cli2-action@v16
-        with:
-          globs: "**/*.md"
+  # markdown-lint:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v5
+  #     - name: markdownlint-cli2-action
+  #       uses: DavidAnson/markdownlint-cli2-action@v16
+  #       with:
+  #         globs: "**/*.md"

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -110,7 +110,7 @@ jobs:
           build-args: ${{ inputs.build_args }}
 
       - name: Build test image for linux/amd64
-        if: matrix.spec.name == 'docling-project/docling-serve'
+        if: contains(inputs.platforms, 'amd64') && inputs.ghcr_image_name == 'docling-project/docling-serve'
         id: ghcr_build_test
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -53,7 +53,7 @@ jobs:
             df -h
 
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to the GHCR container image registry
         if: ${{ inputs.publish }}
@@ -88,12 +88,19 @@ jobs:
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ inputs.ghcr_image_name }}
 
+      ## Local test
+      # - name: Set metadata outputs for local testing, and comment out: Free up space, Log in to cr, Cache Docker, Extract metadata, and quay blocks
+      #   id: ghcr_meta
+      #   run: |
+      #     echo "tags=ghcr.io/docling-project/docling-serve:pr-123" >> $GITHUB_OUTPUT
+      #     echo "labels=org.opencontainers.image.source=https://github.com/docling-project/docling-serve" >> $GITHUB_OUTPUT
+
       - name: Build and push image to ghcr.io
         id: ghcr_push
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ inputs.publish }} # set false for local test
+          push: ${{ inputs.publish }} # set 'false' for local test
           tags: ${{ steps.ghcr_meta.outputs.tags }}
           labels: ${{ steps.ghcr_meta.outputs.labels }}
           platforms: ${{ inputs.platforms}}
@@ -101,6 +108,76 @@ jobs:
           cache-to: type=gha,mode=max
           file: Containerfile
           build-args: ${{ inputs.build_args }}
+
+      - name: Tests local image
+        run: |
+          set -e
+
+          IMAGE_TAG="${{ steps.ghcr_meta.outputs.tags }}"
+          echo "Testing local image: $IMAGE_TAG"
+
+          # Remove existing container if any
+          docker rm -f docling-serve-test-container 2>/dev/null || true
+
+          echo "Starting container..."
+          docker run -d -p 5001:5001 --name docling-serve-test-container "$IMAGE_TAG"
+
+          echo "Waiting 15s for container to boot..."
+          sleep 15
+
+          echo "Checking service health..."
+          for i in {1..20}; do
+            HEALTH_RESPONSE=$(curl -s http://localhost:5001/health || true)
+            echo "Health check response [$i]: $HEALTH_RESPONSE"
+
+            if echo "$HEALTH_RESPONSE" | grep -q '"status":"ok"'; then
+              echo "Service is healthy! Sending test conversion request..."
+
+              STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST 'http://localhost:5001/v1/convert/source' \
+                -H 'accept: application/json' \
+                -H 'Content-Type: application/json' \
+                -d '{
+                  "options": {
+                    "from_formats": ["pdf"],
+                    "to_formats": ["md"]
+                  },
+                  "sources": [
+                    {
+                      "kind": "http",
+                      "url": "https://arxiv.org/pdf/2501.17887"
+                    }
+                  ],
+                  "target": {
+                    "kind": "inbody"
+                  }
+                }')
+
+              echo "Conversion request returned status code: $STATUS_CODE"
+
+              if [ "$STATUS_CODE" -ne 200 ]; then
+                echo "Conversion failed!"
+                docker logs docling-serve-test-container
+                docker rm -f docling-serve-test-container
+                exit 1
+              fi
+
+              break
+            else
+              echo "Waiting for service... [$i/20]"
+              sleep 3
+            fi
+          done
+
+          # Final health check
+          if ! echo "$HEALTH_RESPONSE" | grep -q '"status":"ok"'; then
+            echo "Service did not become healthy in time."
+            docker logs docling-serve-test-container
+            docker rm -f docling-serve-test-container
+            exit 1
+          fi
+
+          echo "Cleaning up test container..."
+          docker rm -f docling-serve-test-container
 
       - name: Generate artifact attestation
         if: ${{ inputs.publish }}
@@ -123,7 +200,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ inputs.publish }} # set false for local test
+          push: ${{ inputs.publish }}
           tags: ${{ steps.quay_meta.outputs.tags }}
           labels: ${{ steps.quay_meta.outputs.labels }}
           platforms: ${{ inputs.platforms}}
@@ -132,208 +209,209 @@ jobs:
           file: Containerfile
           build-args: ${{ inputs.build_args }}
 
-      # - name: Inspect the image details
-      #   run: |
-      #     echo "${{ steps.ghcr_push.outputs.metadata }}"
-
       - name: Remove Local Docker Images
         run: |
           docker image prune -af
+##
+## Tests for released images
+##
 
-      # - name: Set metadata outputs for local testing, and comment out buildx, cache, metadata
+      ## Local test
+      # - name: Set metadata outputs for local testing, and comment out: Free up space, Log in to cr, Cache Docker, Extract metadata, and quay blocks
       #   id: ghcr_meta
       #   run: |
-      #     echo "tags=ghcr.io/docling-project/docling-serve-cpu:main" >> $GITHUB_OUTPUT
+      #     echo "tags=ghcr.io/docling-project/docling-serve-cpu:v1.2.0" >> $GITHUB_OUTPUT
       #     echo "labels=org.opencontainers.image.source=https://github.com/docling-project/docling-serve" >> $GITHUB_OUTPUT
 
-    outputs:
-      image-tags: ${{ steps.ghcr_meta.outputs.tags }}
-      image-labels: ${{ steps.ghcr_meta.outputs.labels }}
+    ## GH
+    # outputs:
+    #   image-tags: ${{ steps.ghcr_meta.outputs.tags }}
+    #   image-labels: ${{ steps.ghcr_meta.outputs.labels }}
 
-  test-cpu-image:
-    needs:
-      - image
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
+  # test-cpu-image:
+  #   needs:
+  #     - image
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
+  #     packages: read
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v5
 
-      - name: Test CPU images
-        run: |
-          set -e
+  #     - name: Test CPU images
+  #       run: |
+  #         set -e
 
-          echo "Testing image: ${{ needs.image.outputs.image-tags }}"
+  #         echo "Testing image: ${{ needs.image.outputs.image-tags }}"
 
-          for tag in ${{ needs.image.outputs.image-tags }}; do
-            if echo "$tag" | grep -q -- '-cpu' && echo "$tag" | grep -qE ':[vV][0-9]+(\.[0-9]+){0,2}$'; then
-              echo "Testing CPU image: $tag"
+  #         for tag in ${{ needs.image.outputs.image-tags }}; do
+  #           if echo "$tag" | grep -q -- '-cpu' && echo "$tag" | grep -qE ':[vV][0-9]+(\.[0-9]+){0,2}$'; then
+  #             echo "Testing CPU image: $tag"
 
-              # Remove existing container if any
-              docker rm -f docling-serve-test-container 2>/dev/null || true
+  #             # Remove existing container if any
+  #             docker rm -f docling-serve-test-container 2>/dev/null || true
 
-              echo "Pulling image..."
-              docker pull "$tag"
+  #             echo "Pulling image..."
+  #             docker pull "$tag"
 
-              echo "Waiting 5s after pull..."
-              sleep 5
+  #             echo "Waiting 5s after pull..."
+  #             sleep 5
 
-              echo "Starting container..."
-              docker run -d -p 5001:5001 --name docling-serve-test-container "$tag"
+  #             echo "Starting container..."
+  #             docker run -d -p 5001:5001 --name docling-serve-test-container "$tag"
 
-              echo "Waiting 15s for container to boot..."
-              sleep 15
+  #             echo "Waiting 15s for container to boot..."
+  #             sleep 15
 
-              echo "Checking service health..."
-              for i in {1..20}; do
-                health_response=$(curl -s http://localhost:5001/health || true)
-                echo "Health check response [$i]: $health_response"
-                if echo "$health_response" | grep -q '"status":"ok"'; then
-                  echo "Service is healthy!"
-                  echo "Sending test conversion request..."
+  #             echo "Checking service health..."
+  #             for i in {1..20}; do
+  #               health_response=$(curl -s http://localhost:5001/health || true)
+  #               echo "Health check response [$i]: $health_response"
+  #               if echo "$health_response" | grep -q '"status":"ok"'; then
+  #                 echo "Service is healthy!"
+  #                 echo "Sending test conversion request..."
 
-                  status_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST 'http://localhost:5001/v1/convert/source' \
-                    -H 'accept: application/json' \
-                    -H 'Content-Type: application/json' \
-                    -d '{
-                      "options": {
-                        "from_formats": ["pdf"],
-                        "to_formats": ["md"]
-                      },
-                      "sources": [
-                        {
-                          "kind": "http",
-                          "url": "https://arxiv.org/pdf/2501.17887"
-                        }
-                      ],
-                      "target": {
-                        "kind": "inbody"
-                      }
-                    }')
+  #                 status_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST 'http://localhost:5001/v1/convert/source' \
+  #                   -H 'accept: application/json' \
+  #                   -H 'Content-Type: application/json' \
+  #                   -d '{
+  #                     "options": {
+  #                       "from_formats": ["pdf"],
+  #                       "to_formats": ["md"]
+  #                     },
+  #                     "sources": [
+  #                       {
+  #                         "kind": "http",
+  #                         "url": "https://arxiv.org/pdf/2501.17887"
+  #                       }
+  #                     ],
+  #                     "target": {
+  #                       "kind": "inbody"
+  #                     }
+  #                   }')
 
-                  echo "Conversion request returned status code: $status_code"
+  #                 echo "Conversion request returned status code: $status_code"
 
-                  if [ "$status_code" -ne 200 ]; then
-                    echo "Conversion failed!"
-                    docker logs docling-serve-test-container
-                    docker rm -f docling-serve-test-container
-                    exit 1
-                  fi
+  #                 if [ "$status_code" -ne 200 ]; then
+  #                   echo "Conversion failed!"
+  #                   docker logs docling-serve-test-container
+  #                   docker rm -f docling-serve-test-container
+  #                   exit 1
+  #                 fi
 
-                  break
-                else
-                  echo "Waiting for service... [$i/20]"
-                  sleep 3
-                fi
-              done
+  #                 break
+  #               else
+  #                 echo "Waiting for service... [$i/20]"
+  #                 sleep 3
+  #               fi
+  #             done
 
-              if ! echo "$health_response" | grep -q '"status":"ok"'; then
-                echo "Service did not become healthy in time."
-                docker logs docling-serve-test-container
-                docker rm -f docling-serve-test-container
-                exit 1
-              fi
+  #             if ! echo "$health_response" | grep -q '"status":"ok"'; then
+  #               echo "Service did not become healthy in time."
+  #               docker logs docling-serve-test-container
+  #               docker rm -f docling-serve-test-container
+  #               exit 1
+  #             fi
 
-              echo "Cleaning up test container..."
-              docker rm -f docling-serve-test-container
-            else
-              echo "Skipping non-released or non-CPU image: $tag"
-            fi
-          done
+  #             echo "Cleaning up test container..."
+  #             docker rm -f docling-serve-test-container
+  #           else
+  #             echo "Skipping non-released or non-CPU image: $tag"
+  #           fi
+  #         done
 
-  test-cuda-image:
-    needs:
-      - image
-    runs-on: ubuntu-latest # >> placeholder for GPU runner << #
-    permissions:
-      contents: read
-      packages: read
+  # test-cuda-image:
+  #   needs:
+  #     - image
+  #   runs-on: ubuntu-latest # >> placeholder for GPU runner << #
+  #   permissions:
+  #     contents: read
+  #     packages: read
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v5
 
-      - name: Test CUDA images
-        run: |
-          set -e
+  #     - name: Test CUDA images
+  #       run: |
+  #         set -e
 
-          echo "Testing image: ${{ needs.image.outputs.image-tags }}"
+  #         echo "Testing image: ${{ needs.image.outputs.image-tags }}"
 
-          for tag in ${{ needs.image.outputs.image-tags }}; do
-            if echo "$tag" | grep -qE -- '-cu[0-9]+' && echo "$tag" | grep -qE ':[vV][0-9]+(\.[0-9]+){0,2}$'; then
-              echo "Testing CUDA image: $tag"
+  #         for tag in ${{ needs.image.outputs.image-tags }}; do
+  #           if echo "$tag" | grep -qE -- '-cu[0-9]+' && echo "$tag" | grep -qE ':[vV][0-9]+(\.[0-9]+){0,2}$'; then
+  #             echo "Testing CUDA image: $tag"
 
-              # Remove existing container if any
-              docker rm -f docling-serve-test-container 2>/dev/null || true
+  #             # Remove existing container if any
+  #             docker rm -f docling-serve-test-container 2>/dev/null || true
 
-              echo "Pulling image..."
-              docker pull "$tag"
+  #             echo "Pulling image..."
+  #             docker pull "$tag"
 
-              echo "Waiting 5s after pull..."
-              sleep 5
+  #             echo "Waiting 5s after pull..."
+  #             sleep 5
 
-              echo "Starting container..."
-              docker run -d -p 5001:5001 --gpus all --name docling-serve-test-container "$tag"
+  #             echo "Starting container..."
+  #             docker run -d -p 5001:5001 --gpus all --name docling-serve-test-container "$tag"
 
-              echo "Waiting 15s for container to boot..."
-              sleep 15
+  #             echo "Waiting 15s for container to boot..."
+  #             sleep 15
 
-              echo "Checking service health..."
-              for i in {1..25}; do
-                health_response=$(curl -s http://localhost:5001/health || true)
-                echo "Health check response [$i]: $health_response"
-                if echo "$health_response" | grep -q '"status":"ok"'; then
-                  echo "Service is healthy!"
-                  echo "Sending test conversion request..."
+  #             echo "Checking service health..."
+  #             for i in {1..25}; do
+  #               health_response=$(curl -s http://localhost:5001/health || true)
+  #               echo "Health check response [$i]: $health_response"
+  #               if echo "$health_response" | grep -q '"status":"ok"'; then
+  #                 echo "Service is healthy!"
+  #                 echo "Sending test conversion request..."
 
-                  status_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST 'http://localhost:5001/v1/convert/source' \
-                    -H 'accept: application/json' \
-                    -H 'Content-Type: application/json' \
-                    -d '{
-                      "options": {
-                        "from_formats": ["pdf"],
-                        "to_formats": ["md"]
-                      },
-                      "sources": [
-                        {
-                          "kind": "http",
-                          "url": "https://arxiv.org/pdf/2501.17887"
-                        }
-                      ],
-                      "target": {
-                        "kind": "inbody"
-                      }
-                    }')
+  #                 status_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST 'http://localhost:5001/v1/convert/source' \
+  #                   -H 'accept: application/json' \
+  #                   -H 'Content-Type: application/json' \
+  #                   -d '{
+  #                     "options": {
+  #                       "from_formats": ["pdf"],
+  #                       "to_formats": ["md"]
+  #                     },
+  #                     "sources": [
+  #                       {
+  #                         "kind": "http",
+  #                         "url": "https://arxiv.org/pdf/2501.17887"
+  #                       }
+  #                     ],
+  #                     "target": {
+  #                       "kind": "inbody"
+  #                     }
+  #                   }')
 
-                  echo "Conversion request returned status code: $status_code"
+  #                 echo "Conversion request returned status code: $status_code"
 
-                  if [ "$status_code" -ne 200 ]; then
-                    echo "Conversion failed!"
-                    docker logs docling-serve-test-container
-                    docker rm -f docling-serve-test-container
-                    exit 1
-                  fi
+  #                 if [ "$status_code" -ne 200 ]; then
+  #                   echo "Conversion failed!"
+  #                   docker logs docling-serve-test-container
+  #                   docker rm -f docling-serve-test-container
+  #                   exit 1
+  #                 fi
 
-                  break
-                else
-                  echo "Waiting for service... [$i/25]"
-                  sleep 3
-                fi
-              done
+  #                 break
+  #               else
+  #                 echo "Waiting for service... [$i/25]"
+  #                 sleep 3
+  #               fi
+  #             done
 
-              if ! echo "$health_response" | grep -q '"status":"ok"'; then
-                echo "Service did not become healthy in time."
-                docker logs docling-serve-test-container
-                docker rm -f docling-serve-test-container
-                exit 1
-              fi
+  #             if ! echo "$health_response" | grep -q '"status":"ok"'; then
+  #               echo "Service did not become healthy in time."
+  #               docker logs docling-serve-test-container
+  #               docker rm -f docling-serve-test-container
+  #               exit 1
+  #             fi
 
-              echo "Cleaning up test container..."
-              docker rm -f docling-serve-test-container
-            else
-              echo "Skipping non-released or non-CUDA image: $tag"
-            fi
-          done
+  #             echo "Cleaning up test container..."
+  #             docker rm -f docling-serve-test-container
+  #           else
+  #             echo "Skipping non-released or non-CUDA image: $tag"
+  #           fi
+  #         done

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -93,7 +93,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ inputs.publish }}
+          push: ${{ inputs.publish }} # set false for local test
           tags: ${{ steps.ghcr_meta.outputs.tags }}
           labels: ${{ steps.ghcr_meta.outputs.labels }}
           platforms: ${{ inputs.platforms}}
@@ -101,14 +101,6 @@ jobs:
           cache-to: type=gha,mode=max
           file: Containerfile
           build-args: ${{ inputs.build_args }}
-
-      - name: Generate artifact attestation
-        if: ${{ inputs.publish }}
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.GHCR_REGISTRY }}/${{ inputs.ghcr_image_name }}
-          subject-digest: ${{ steps.ghcr_push.outputs.digest }}
-          push-to-registry: true
 
       - name: Extract metadata (tags, labels) for docling-serve quay image
         if: ${{ inputs.publish }}
@@ -123,7 +115,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ inputs.publish }}
+          push: ${{ inputs.publish }} # set false for local test
           tags: ${{ steps.quay_meta.outputs.tags }}
           labels: ${{ steps.quay_meta.outputs.labels }}
           platforms: ${{ inputs.platforms}}
@@ -131,7 +123,7 @@ jobs:
           cache-to: type=gha,mode=max
           file: Containerfile
           build-args: ${{ inputs.build_args }}
-      
+
       # - name: Inspect the image details
       #   run: |
       #     echo "${{ steps.ghcr_push.outputs.metadata }}"
@@ -139,3 +131,201 @@ jobs:
       - name: Remove Local Docker Images
         run: |
           docker image prune -af
+
+      # - name: Set metadata outputs for local testing, and comment out buildx, cache, metadata
+      #   id: ghcr_meta
+      #   run: |
+      #     echo "tags=ghcr.io/docling-project/docling-serve-cpu:main" >> $GITHUB_OUTPUT
+      #     echo "labels=org.opencontainers.image.source=https://github.com/docling-project/docling-serve" >> $GITHUB_OUTPUT
+
+    outputs:
+      image-tags: ${{ steps.ghcr_meta.outputs.tags }}
+      image-labels: ${{ steps.ghcr_meta.outputs.labels }}
+
+  test-cpu-image:
+    needs:
+      - image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Pull and test CPU images
+        run: |
+          set -e  # Exit immediately if any command fails
+
+          echo "All image tags: ${{ needs.image.outputs.image-tags }}"
+
+          for tag in ${{ needs.image.outputs.image-tags }}; do
+            if echo "$tag" | grep -q -- '-cpu'; then
+              echo "Testing CPU image: $tag"
+
+              # Remove existing container if any
+              docker rm -f docling-serve-test-container 2>/dev/null || true
+
+              echo "Pulling image..."
+              docker pull "$tag"
+
+              echo "Waiting 5s after pull..."
+              sleep 5
+
+              echo "Starting container..."
+              docker run -d -p 5001:5001 --name docling-serve-test-container "$tag"
+
+              echo "Waiting 15s for container to boot..."
+              sleep 15
+
+              echo "Checking service health..."
+              for i in {1..20}; do
+                health_response=$(curl -s http://localhost:5001/health || true)
+                echo "Health check response [$i]: $health_response"
+                if echo "$health_response" | grep -q '"status":"ok"'; then
+                  echo "Service is healthy!"
+                  echo "Sending test conversion request..."
+
+                  status_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST 'http://localhost:5001/v1/convert/source' \
+                    -H 'accept: application/json' \
+                    -H 'Content-Type: application/json' \
+                    -d '{
+                      "options": {
+                        "from_formats": ["pdf"],
+                        "to_formats": ["md"]
+                      },
+                      "sources": [
+                        {
+                          "kind": "http",
+                          "url": "https://arxiv.org/pdf/2501.17887"
+                        }
+                      ],
+                      "target": {
+                        "kind": "inbody"
+                      }
+                    }')
+
+                  echo "Conversion request returned status code: $status_code"
+
+                  if [ "$status_code" -ne 200 ]; then
+                    echo "Conversion failed!"
+                    docker logs docling-serve-test-container
+                    docker rm -f docling-serve-test-container
+                    exit 1
+                  fi
+
+                  break
+                else
+                  echo "Waiting for service... [$i/20]"
+                  sleep 3
+                fi
+              done
+
+              if ! echo "$health_response" | grep -q '"status":"ok"'; then
+                echo "Service did not become healthy in time."
+                docker logs docling-serve-test-container
+                docker rm -f docling-serve-test-container
+                exit 1
+              fi
+
+              echo "Cleaning up test container..."
+              docker rm -f docling-serve-test-container
+            else
+              echo "Skipping non-CPU image: $tag"
+            fi
+          done
+
+  test-cuda-image:
+    needs:
+      - image
+    runs-on: ubuntu-latest # >> placeholder for GPU runner << #
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Pull and test CUDA images
+        run: |
+          set -e
+
+          echo "All image tags: ${{ needs.image.outputs.image-tags }}"
+
+          for tag in ${{ needs.image.outputs.image-tags }}; do
+            if echo "$tag" | grep -q -- '-cu'; then
+              echo "Testing CUDA image: $tag"
+
+              # Remove existing container if any
+              docker rm -f docling-serve-test-container 2>/dev/null || true
+
+              echo "Pulling image..."
+              docker pull "$tag"
+
+              echo "Waiting 5s after pull..."
+              sleep 5
+
+              echo "Starting container..."
+              docker run -d -p 5001:5001 --name docling-serve-test-container "$tag"
+
+              echo "Waiting 15s for container to boot..."
+              sleep 15
+
+              echo "Checking service health..."
+              for i in {1..25}; do
+                health_response=$(curl -s http://localhost:5001/health || true)
+                echo "Health check response [$i]: $health_response"
+                if echo "$health_response" | grep -q '"status":"ok"'; then
+                  echo "Service is healthy!"
+                  echo "Sending test conversion request..."
+
+                  status_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST 'http://localhost:5001/v1/convert/source' \
+                    -H 'accept: application/json' \
+                    -H 'Content-Type: application/json' \
+                    -d '{
+                      "options": {
+                        "from_formats": ["pdf"],
+                        "to_formats": ["md"]
+                      },
+                      "sources": [
+                        {
+                          "kind": "http",
+                          "url": "https://arxiv.org/pdf/2501.17887"
+                        }
+                      ],
+                      "target": {
+                        "kind": "inbody"
+                      }
+                    }')
+
+                  echo "Conversion request returned status code: $status_code"
+
+                  if [ "$status_code" -ne 200 ]; then
+                    echo "Conversion failed!"
+                    docker logs docling-serve-test-container
+                    docker rm -f docling-serve-test-container
+                    exit 1
+                  fi
+
+                  break
+                else
+                  echo "Waiting for service... [$i/25]"
+                  sleep 3
+                fi
+              done
+
+              if ! echo "$health_response" | grep -q '"status":"ok"'; then
+                echo "Service did not become healthy in time."
+                docker logs docling-serve-test-container
+                docker rm -f docling-serve-test-container
+                exit 1
+              fi
+
+              echo "Cleaning up test container..."
+              docker rm -f docling-serve-test-container
+            else
+              echo "Skipping non-CUDA image: $tag"
+            fi
+          done

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -108,31 +108,32 @@ jobs:
           cache-to: type=gha,mode=max
           file: Containerfile
           build-args: ${{ inputs.build_args }}
-
-      - name: Build test image for linux/amd64
-        if: contains(inputs.platforms, 'amd64') && inputs.ghcr_image_name == 'docling-project/docling-serve'
-        id: ghcr_build_test
+      ##
+      ## This stage runs after the build, so it leverages all build cache
+      ## 
+      - name: Export built image for testing (--output=type=docker)
+        id: ghcr_export_built_image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: false
           load: true
-          tags: docling-serve:test
+          tags: ${{ steps.ghcr_meta.outputs.tags }}-test
           labels: |
             org.opencontainers.image.title=docling-serve
             org.opencontainers.image.test=true
-          platforms: linux/amd64
+          platforms: linux/amd64 # when 'load' is true, we can't use a list ${{ inputs.platforms }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: Containerfile
           build-args: ${{ inputs.build_args }}
 
-      - name: Test image for linux/amd64
-        if: steps.ghcr_build_test.outcome == 'success'
+      - name: Test image
+        if: steps.ghcr_export_built_image.outcome == 'success'
         run: |
           set -e
 
-          IMAGE_TAG="docling-serve:test"
+          IMAGE_TAG="${{ steps.ghcr_meta.outputs.tags }}-test"
           echo "Testing local image: $IMAGE_TAG"
 
           # Remove existing container if any

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -127,6 +127,7 @@ jobs:
           build-args: UV_SYNC_EXTRA_ARGS=--no-extra flash-attn
 
       - name: Test image for linux/amd64
+        if: steps.ghcr_build_test.outcome == 'success'
         run: |
           set -e
 

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -97,12 +97,10 @@ jobs:
 
       - name: Build and push image to ghcr.io
         id: ghcr_push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ inputs.publish }} # set 'false' for local test
-          # Uses output instead of load for multi-platform
-          output: type=docker
           tags: ${{ steps.ghcr_meta.outputs.tags }}
           labels: ${{ steps.ghcr_meta.outputs.labels }}
           platforms: ${{ inputs.platforms }}
@@ -111,11 +109,28 @@ jobs:
           file: Containerfile
           build-args: ${{ inputs.build_args }}
 
-      - name: Tests local image
+      - name: Build test image for linux/amd64
+        id: ghcr_build_test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: docling-serve:test
+          labels: |
+            org.opencontainers.image.title=docling-serve
+            org.opencontainers.image.test=true
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: Containerfile
+          build-args: UV_SYNC_EXTRA_ARGS=--no-extra flash-attn
+
+      - name: Test image for linux/amd64
         run: |
           set -e
 
-          IMAGE_TAG="${{ steps.ghcr_meta.outputs.tags }}"
+          IMAGE_TAG="docling-serve:test"
           echo "Testing local image: $IMAGE_TAG"
 
           # Remove existing container if any
@@ -199,7 +214,7 @@ jobs:
       - name: Build and push image to quay.io
         if: ${{ inputs.publish }}
         # id: push-serve-cpu-quay
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ inputs.publish }}

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -101,6 +101,7 @@ jobs:
         with:
           context: .
           push: ${{ inputs.publish }} # set 'false' for local test
+          load: true
           tags: ${{ steps.ghcr_meta.outputs.tags }}
           labels: ${{ steps.ghcr_meta.outputs.labels }}
           platforms: ${{ inputs.platforms}}

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -101,10 +101,11 @@ jobs:
         with:
           context: .
           push: ${{ inputs.publish }} # set 'false' for local test
-          load: true
+          # Uses output instead of load for multi-platform
+          output: type=docker
           tags: ${{ steps.ghcr_meta.outputs.tags }}
           labels: ${{ steps.ghcr_meta.outputs.labels }}
-          platforms: ${{ inputs.platforms}}
+          platforms: ${{ inputs.platforms }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: Containerfile

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -88,8 +88,8 @@ jobs:
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ inputs.ghcr_image_name }}
 
-      ## Local test
-      # - name: Set metadata outputs for local testing, and comment out: Free up space, Log in to cr, Cache Docker, Extract metadata, and quay blocks
+      # # Local test
+      # - name: Set metadata outputs for local testing ## comment out Free up space, Log in to cr, Cache Docker, Extract metadata, and quay blocks and run act
       #   id: ghcr_meta
       #   run: |
       #     echo "tags=ghcr.io/docling-project/docling-serve:pr-123" >> $GITHUB_OUTPUT
@@ -111,13 +111,13 @@ jobs:
       ##
       ## This stage runs after the build, so it leverages all build cache
       ## 
-      - name: Export built image for testing (--output=type=docker)
+      - name: Export built image for testing
         id: ghcr_export_built_image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: false
-          load: true
+          load: true # == '--output=type=docker'
           tags: ${{ steps.ghcr_meta.outputs.tags }}-test
           labels: |
             org.opencontainers.image.title=docling-serve
@@ -145,42 +145,44 @@ jobs:
           echo "Waiting 15s for container to boot..."
           sleep 15
 
+          # Step 1: Health check
           echo "Checking service health..."
           for i in {1..20}; do
             HEALTH_RESPONSE=$(curl -s http://localhost:5001/health || true)
             echo "Health check response [$i]: $HEALTH_RESPONSE"
 
             if echo "$HEALTH_RESPONSE" | grep -q '"status":"ok"'; then
-              echo "Service is healthy! Sending test conversion request..."
+              echo "Service is healthy!"
 
-              STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST 'http://localhost:5001/v1/convert/source' \
-                -H 'accept: application/json' \
-                -H 'Content-Type: application/json' \
-                -d '{
-                  "options": {
-                    "from_formats": ["pdf"],
-                    "to_formats": ["md"]
-                  },
-                  "sources": [
-                    {
-                      "kind": "http",
-                      "url": "https://arxiv.org/pdf/2501.17887"
-                    }
-                  ],
-                  "target": {
-                    "kind": "inbody"
-                  }
-                }')
+              # Step 2: Install pytest and dependencies
+              echo "Installing pytest and dependencies..."
+              pip install uv
+              uv venv --allow-existing
+              source .venv/bin/activate
+              uv sync --all-extras --no-extra flash-attn
 
-              echo "Conversion request returned status code: $STATUS_CODE"
+              # Step 3: Run pytest tests
+              echo "Running tests..."
+              # Test import
+              python -c 'from docling_serve.app import create_app; create_app()'
+              # Run pytest
+              pytest -v -k "test_convert_url" \
+                --disable-warnings \
+                --ignore tests/test_fastapi_endpoints.py \
+                --ignore tests/test_1-file-all-outputs.py \
+                --ignore tests/test_1-url-all-outputs.py \
+                --ignore tests/test_2-files-all-outputs.py \
+                --ignore tests/test_2-urls-all-outputs.py
 
-              if [ "$STATUS_CODE" -ne 200 ]; then
-                echo "Conversion failed!"
+              # Check pytest result
+              if [ $? -ne 0 ]; then
+                echo "Tests failed!"
                 docker logs docling-serve-test-container
                 docker rm -f docling-serve-test-container
                 exit 1
               fi
 
+              echo "Tests passed successfully!"
               break
             else
               echo "Waiting for service... [$i/20]"
@@ -188,7 +190,7 @@ jobs:
             fi
           done
 
-          # Final health check
+          # Final health check if service didn't pass earlier
           if ! echo "$HEALTH_RESPONSE" | grep -q '"status":"ok"'; then
             echo "Service did not become healthy in time."
             docker logs docling-serve-test-container
@@ -196,6 +198,7 @@ jobs:
             exit 1
           fi
 
+          # Step 5: Cleanup
           echo "Cleaning up test container..."
           docker rm -f docling-serve-test-container
 
@@ -233,17 +236,9 @@ jobs:
         run: |
           docker image prune -af
 ##
-## Tests for released images
+## Extra tests for released images
 ##
 
-      ## Local test
-      # - name: Set metadata outputs for local testing, and comment out: Free up space, Log in to cr, Cache Docker, Extract metadata, and quay blocks
-      #   id: ghcr_meta
-      #   run: |
-      #     echo "tags=ghcr.io/docling-project/docling-serve-cpu:v1.2.0" >> $GITHUB_OUTPUT
-      #     echo "labels=org.opencontainers.image.source=https://github.com/docling-project/docling-serve" >> $GITHUB_OUTPUT
-
-    ## GH
     # outputs:
     #   image-tags: ${{ steps.ghcr_meta.outputs.tags }}
     #   image-labels: ${{ steps.ghcr_meta.outputs.labels }}

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -102,6 +102,14 @@ jobs:
           file: Containerfile
           build-args: ${{ inputs.build_args }}
 
+      - name: Generate artifact attestation
+        if: ${{ inputs.publish }}
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.GHCR_REGISTRY }}/${{ inputs.ghcr_image_name }}
+          subject-digest: ${{ steps.ghcr_push.outputs.digest }}
+          push-to-registry: true
+
       - name: Extract metadata (tags, labels) for docling-serve quay image
         if: ${{ inputs.publish }}
         id: quay_meta
@@ -152,16 +160,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Pull and test CPU images
+      - name: Test CPU images
         run: |
-          set -e  # Exit immediately if any command fails
+          set -e
 
-          echo "All image tags: ${{ needs.image.outputs.image-tags }}"
+          echo "Testing image: ${{ needs.image.outputs.image-tags }}"
 
           for tag in ${{ needs.image.outputs.image-tags }}; do
-            if echo "$tag" | grep -q -- '-cpu'; then
+            if echo "$tag" | grep -q -- '-cpu' && echo "$tag" | grep -qE ':[vV][0-9]+(\.[0-9]+){0,2}$'; then
               echo "Testing CPU image: $tag"
 
               # Remove existing container if any
@@ -232,7 +240,7 @@ jobs:
               echo "Cleaning up test container..."
               docker rm -f docling-serve-test-container
             else
-              echo "Skipping non-CPU image: $tag"
+              echo "Skipping non-released or non-CPU image: $tag"
             fi
           done
 
@@ -246,16 +254,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Pull and test CUDA images
+      - name: Test CUDA images
         run: |
           set -e
 
-          echo "All image tags: ${{ needs.image.outputs.image-tags }}"
+          echo "Testing image: ${{ needs.image.outputs.image-tags }}"
 
           for tag in ${{ needs.image.outputs.image-tags }}; do
-            if echo "$tag" | grep -q -- '-cu'; then
+            if echo "$tag" | grep -qE -- '-cu[0-9]+' && echo "$tag" | grep -qE ':[vV][0-9]+(\.[0-9]+){0,2}$'; then
               echo "Testing CUDA image: $tag"
 
               # Remove existing container if any
@@ -326,6 +334,6 @@ jobs:
               echo "Cleaning up test container..."
               docker rm -f docling-serve-test-container
             else
-              echo "Skipping non-CUDA image: $tag"
+              echo "Skipping non-released or non-CUDA image: $tag"
             fi
           done

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -110,6 +110,7 @@ jobs:
           build-args: ${{ inputs.build_args }}
 
       - name: Build test image for linux/amd64
+        if: matrix.spec.name == 'docling-project/docling-serve'
         id: ghcr_build_test
         uses: docker/build-push-action@v6
         with:
@@ -124,7 +125,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: Containerfile
-          build-args: UV_SYNC_EXTRA_ARGS=--no-extra flash-attn
+          build-args: ${{ inputs.build_args }}
 
       - name: Test image for linux/amd64
         if: steps.ghcr_build_test.outcome == 'success'

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -268,7 +268,7 @@ jobs:
               sleep 5
 
               echo "Starting container..."
-              docker run -d -p 5001:5001 --name docling-serve-test-container "$tag"
+              docker run -d -p 5001:5001 --gpus all --name docling-serve-test-container "$tag"
 
               echo "Waiting 15s for container to boot..."
               sleep 15

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -145,7 +145,7 @@ jobs:
           echo "Waiting 15s for container to boot..."
           sleep 15
 
-          # Step 1: Health check
+          # Health check
           echo "Checking service health..."
           for i in {1..20}; do
             HEALTH_RESPONSE=$(curl -s http://localhost:5001/health || true)
@@ -154,14 +154,14 @@ jobs:
             if echo "$HEALTH_RESPONSE" | grep -q '"status":"ok"'; then
               echo "Service is healthy!"
 
-              # Step 2: Install pytest and dependencies
+              # Install pytest and dependencies
               echo "Installing pytest and dependencies..."
               pip install uv
               uv venv --allow-existing
               source .venv/bin/activate
               uv sync --all-extras --no-extra flash-attn
 
-              # Step 3: Run pytest tests
+              # Run pytest tests
               echo "Running tests..."
               # Test import
               python -c 'from docling_serve.app import create_app; create_app()'
@@ -198,7 +198,7 @@ jobs:
             exit 1
           fi
 
-          # Step 5: Cleanup
+          # Cleanup
           echo "Cleaning up test container..."
           docker rm -f docling-serve-test-container
 

--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -165,17 +165,10 @@ jobs:
               echo "Running tests..."
               # Test import
               python -c 'from docling_serve.app import create_app; create_app()'
-              # Run pytest
-              pytest -v -k "test_convert_url" \
-                --disable-warnings \
-                --ignore tests/test_fastapi_endpoints.py \
-                --ignore tests/test_1-file-all-outputs.py \
-                --ignore tests/test_1-url-all-outputs.py \
-                --ignore tests/test_2-files-all-outputs.py \
-                --ignore tests/test_2-urls-all-outputs.py
 
-              # Check pytest result
-              if [ $? -ne 0 ]; then
+              # Run pytest and check result directly
+              if ! pytest -sv -k "test_convert_url" tests/test_1-url-async.py \
+                --disable-warnings; then
                 echo "Tests failed!"
                 docker logs docling-serve-test-container
                 docker rm -f docling-serve-test-container


### PR DESCRIPTION
regarding build and tests:
- updated actions versions
- the new test stage, runs after the build, and so it uses the build cache, one is just exporting the build cache to docker 
```load: true # == '--output=type=docker'```
- it runs for all images
- stage does: mounts container, checks health, runs pytest, cleanup
- adds images tests for released, `-cpu` and `-cu*`  (commented out now,maybe not needed anymore)

regarding releases:
- adds docling packages versions to changelog, from ```uv.lock```

ref https://github.com/docling-project/docling-serve/issues/302