### PR TITLE
docs: document DOCLING_NUM_THREADS environment variable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,7 @@ THe following table describes the options to configure the Docling Serve app.
 |  | `DOCLING_SERVE_SINGLE_USE_RESULTS` | `true` | If true, results can be accessed only once. If false, the results accumulate in the scratch directory. |
 |  | `DOCLING_SERVE_RESULT_REMOVAL_DELAY` | `300` | When `DOCLING_SERVE_SINGLE_USE_RESULTS` is active, this is the delay before results are removed from the task registry. |
 |  | `DOCLING_SERVE_MAX_DOCUMENT_TIMEOUT` | `604800` (7 days) | The maximum time for processing a document. |
+|  | `DOCLING_NUM_THREADS` | `4` | Number of concurrent threads for processing a document. |
 |  | `DOCLING_SERVE_MAX_NUM_PAGES` |  | The maximum number of pages for a document to be processed. |
 |  | `DOCLING_SERVE_MAX_FILE_SIZE` |  | The maximum file size for a document to be processed. |
 |  | `DOCLING_SERVE_MAX_SYNC_WAIT` | `120` | Max number of seconds a synchronous endpoint is waiting for the task completion. |


### PR DESCRIPTION
Myself and some other user were wondering how one can increase the number of threads when processing a document. It turns out this is already possible, just undocumented.

All the best

**Issue resolved by this Pull Request:**
Resolves #257
