### PR TITLE
ci: fix runner disk space issue

### DIFF
--- a/.github/workflows/job-image.yml
+++ b/.github/workflows/job-image.yml
@@ -194,6 +194,8 @@ jobs:
           # Cleanup
           echo "Cleaning up test container..."
           docker rm -f docling-serve-test-container
+          echo "Cleaning up test image..."
+          docker rmi "$IMAGE_TAG"
 
       - name: Generate artifact attestation
         if: ${{ inputs.publish }}


### PR DESCRIPTION
```
error: Check build summary support
Error: buildx failed with: ERROR: failed to build: failed to solve: rpc error: code = Unknown desc = write /opt/app-root/lib/python3.12/site-packages/cusparselt/lib/libcusparseLt.so.0: no space left on device

```

- added step to cleanup test image when done, which is meant to clear some space and keep build cache intact
- 🤞 