### PR TITLE
fix: updates rapidocr deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,9 @@ tesserocr = [
     "tesserocr~=2.7"
 ]
 rapidocr = [
-    "rapidocr-onnxruntime~=1.4; python_version<'3.13'",
-    "onnxruntime~=1.7",
+    "rapidocr (>=3.3,<4.0.0) ; python_version < '3.14'",
+    "onnxruntime (>=1.7.0,<2.0.0)",
+      "modelscope>=1.29.0",
 ]
 flash-attn = [
   "flash-attn~=2.8.2; sys_platform == 'linux' and platform_machine == 'x86_64'"


### PR DESCRIPTION

- rapidocr was updated in docling upstream at https://github.com/docling-project/docling/pull/2088
- docling-serve was still installing the previous package version hence this issue https://github.com/docling-project/docling-serve/issues/360

