### PR TITLE
Added arm64 platform for pr, enabled pr image push

### DIFF
--- a/.github/workflows/ci-images-dryrun.yml
+++ b/.github/workflows/ci-images-dryrun.yml
@@ -32,7 +32,7 @@ jobs:
           - name: docling-project/docling-serve-cu128
             build_args: |
               UV_SYNC_EXTRA_ARGS=--no-group pypi --group cu128
-            platforms: linux/amd64
+            platforms: linux/amd64, linux/arm64
           # - name: docling-project/docling-serve-rocm
           #   build_args: |
           #     UV_SYNC_EXTRA_ARGS=--no-group pypi --group rocm --no-extra flash-attn
@@ -43,10 +43,12 @@ jobs:
       contents: read
       attestations: write
       id-token: write
+    secrets: inherit
 
     uses: ./.github/workflows/job-image.yml
     with:
-      publish: false
+      publish: true
+      environment: registry-creds
       build_args: ${{ matrix.spec.build_args }}
       ghcr_image_name: ${{ matrix.spec.name }}
       quay_image_name: ""


### PR DESCRIPTION
Not 100% sure if this is enough but we can give it a try.
Didn't made changes for cu126 because these versions:
```
cu126 = [
  "torch>=2.6.0,<=2.6.0",
  "torchvision>=0.21.0",
]
```
run into conflict with vllm.
