### PR TITLE
test: check that processing time is not skipped

### DIFF
--- a/tests/test_1-url-async-ws.py
+++ b/tests/test_1-url-async-ws.py
@@ -69,3 +69,9 @@ async def test_convert_url(async_client: httpx.AsyncClient):
     with connect(uri) as websocket:
         for message in websocket:
             print(message)
+
+    result_resp = await async_client.get(f"{base_url}/result/{task['task_id']}")
+    assert result_resp.status_code == 200, "Response should be 200 OK"
+    result = result_resp.json()
+    print(f"{result['processing_time']=}")
+    assert result["processing_time"] > 1.0


### PR DESCRIPTION
Locally this is producing

```
result['processing_time']=7.438237625057809
```

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
