### PR TITLE
feat: Add DOCLING_SERVE_LOG_LEVEL environment variable support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 TESSDATA_PREFIX=/usr/share/tesseract/tessdata/
 UVICORN_WORKERS=2
 UVICORN_RELOAD=True
+
+# Logging configuration (case-insensitive)
+# DOCLING_SERVE_LOG_LEVEL=WARNING  # Options: WARNING, INFO, DEBUG (or warning, info, debug)

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 from typing import Optional, Union
 
-from pydantic import AnyUrl, model_validator
+from pydantic import AnyUrl, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Self
 
@@ -25,6 +25,12 @@ class UvicornSettings(BaseSettings):
     workers: Union[int, None] = None
 
 
+class LogLevel(str, enum.Enum):
+    WARNING = "WARNING"
+    INFO = "INFO"
+    DEBUG = "DEBUG"
+
+
 class AsyncEngine(str, enum.Enum):
     LOCAL = "local"
     KFP = "kfp"
@@ -41,6 +47,7 @@ class DoclingServeSettings(BaseSettings):
 
     enable_ui: bool = False
     api_host: str = "localhost"
+    log_level: Optional[LogLevel] = None
     artifacts_path: Optional[Path] = None
     static_path: Optional[Path] = None
     scratch_path: Optional[Path] = None
@@ -97,6 +104,16 @@ class DoclingServeSettings(BaseSettings):
     otel_enable_prometheus: bool = True
     otel_enable_otlp_metrics: bool = False
     otel_service_name: str = "docling-serve"
+
+    @field_validator("log_level", mode="before")
+    @classmethod
+    def validate_log_level(cls, v: Optional[str]) -> Optional[str]:
+        """Validate and normalize log level to uppercase for case-insensitive support."""
+        if v is None:
+            return v
+        if isinstance(v, str):
+            return v.upper()
+        return v
 
     @model_validator(mode="after")
     def engine_settings(self) -> Self:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,7 @@ THe following table describes the options to configure the Docling Serve app.
 
 | CLI option | ENV | Default | Description |
 | -----------|-----|---------|-------------|
+| `-v, --verbose` | `DOCLING_SERVE_LOG_LEVEL` | `WARNING` | Set the verbosity level. CLI: `-v` for INFO, `-vv` for DEBUG. ENV: `WARNING`, `INFO`, or `DEBUG` (case-insensitive). CLI flag takes precedence over ENV. |
 | `--artifacts-path` | `DOCLING_SERVE_ARTIFACTS_PATH` | unset | If set to a valid directory, the model weights will be loaded from this path |
 |  | `DOCLING_SERVE_STATIC_PATH` | unset | If set to a valid directory, the static assets for the docs and UI will be loaded from this path |
 |  | `DOCLING_SERVE_SCRATCH_PATH` |  | If set, this directory will be used as scratch workspace, e.g. storing the results before they get requested. If unset, a temporary created is created for this purpose. |


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

## Description

This PR adds support for configuring logging levels via environment variable and improves the logging configuration priority system.

### Changes:

1. **Added `DOCLING_SERVE_LOG_LEVEL` environment variable support**: Introduced a new `LogLevel` enum in settings with support for WARNING, INFO, and DEBUG levels
2. **Implemented logging priority system**: 
   - CLI flag (`--verbose`) takes highest precedence
   - Environment variable (`DOCLING_SERVE_LOG_LEVEL`) is used if CLI flag is not provided
   - Default level (WARNING) is used if neither is set
3. **Added case-insensitive log level validation**: The `log_level` field validator normalizes input to uppercase for user convenience (supports both `warning` and `WARNING`)
4. **Applied logging configuration to RQ worker**: The RQ worker now respects the `DOCLING_SERVE_LOG_LEVEL` environment variable, ensuring consistent logging across all components
5. **Updated documentation**: Added configuration examples to `.env.example` and documented the new ENV variable in `docs/configuration.md`

### Benefits:

- More flexible logging configuration for production deployments
- Consistent logging behavior across main application and worker processes
- Maintains backward compatibility with existing `--verbose` CLI flag
- Clear precedence order prevents confusion about which setting takes effect
- Container-friendly configuration (ENV variables work well with multiple workers)

### Usage Examples:

```bash
# Using environment variable (case-insensitive)
export DOCLING_SERVE_LOG_LEVEL=info
docling-serve run

# CLI flag overrides ENV
export DOCLING_SERVE_LOG_LEVEL=warning
docling-serve run -vv  # Uses DEBUG from CLI

# RQ worker respects ENV
export DOCLING_SERVE_LOG_LEVEL=debug
docling-serve rq_worker
```