### PR TITLE
fix: snapshot dict/set iterations in WebsocketNotifier to prevent RuntimeError

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -962,7 +962,9 @@ def create_app():  # noqa: C901
             _log.info(f"WebSocket disconnected for job {task_id}")
 
         finally:
-            orchestrator.notifier.task_subscribers[task_id].remove(websocket)
+            subs = orchestrator.notifier.task_subscribers.get(task_id)
+            if subs:
+                subs.discard(websocket)
 
     # Task result
     @app.get(


### PR DESCRIPTION
Fixes concurrent mutation crashes in  WebsocketNotifier  where  await  yields control mid-iteration, allowing disconnect handlers to mutate the underlying dict/set.

*  remove_task : atomic  pop  +  list()  snapshot before closing sockets
*  notify_task_subscribers :  list(.get())  guards iteration
*  notify_queue_positions : snapshot  keys()  before loop
*  app.py  cleanup:  .get()  +  .discard()  to tolerate already-removed entries

In my tests it eliminated the "dictionary changed size during iteration" error completely

**Issue resolved by this Pull Request:**
Resolves #509 
