### PR TITLE
fix: configure `failure_ttl` for RQ failed jobs

### DIFF
--- a/docling_serve/__main__.py
+++ b/docling_serve/__main__.py
@@ -408,6 +408,7 @@ def rq_worker() -> Any:
         sub_channel=docling_serve_settings.eng_rq_sub_channel,
         scratch_dir=get_scratch(),
         results_ttl=docling_serve_settings.eng_rq_results_ttl,
+        failure_ttl=docling_serve_settings.eng_rq_failure_ttl,
         redis_max_connections=docling_serve_settings.eng_rq_redis_max_connections,
         redis_socket_timeout=docling_serve_settings.eng_rq_redis_socket_timeout,
         redis_socket_connect_timeout=docling_serve_settings.eng_rq_redis_socket_connect_timeout,

--- a/docling_serve/orchestrator_factory.py
+++ b/docling_serve/orchestrator_factory.py
@@ -416,6 +416,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
                     kwargs={"task_data": task_data},
                     job_id=task_id,
                     timeout=14400,
+                    failure_ttl=docling_serve_settings.eng_rq_failure_ttl,
                 )
 
                 await self.init_task_tracking(task)
@@ -431,6 +432,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             sub_channel=docling_serve_settings.eng_rq_sub_channel,
             scratch_dir=get_scratch(),
             results_ttl=docling_serve_settings.eng_rq_results_ttl,
+            failure_ttl=docling_serve_settings.eng_rq_failure_ttl,
             redis_max_connections=docling_serve_settings.eng_rq_redis_max_connections,
             redis_socket_timeout=docling_serve_settings.eng_rq_redis_socket_timeout,
             redis_socket_connect_timeout=docling_serve_settings.eng_rq_redis_socket_connect_timeout,

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -89,6 +89,7 @@ class DoclingServeSettings(BaseSettings):
     eng_rq_results_prefix: str = "docling:results"
     eng_rq_sub_channel: str = "docling:updates"
     eng_rq_results_ttl: int = 3_600 * 4  # 4 hours default
+    eng_rq_failure_ttl: int = 3_600 * 4  # 4 hours default
     eng_rq_redis_max_connections: int = 50  # Connection pool size
     eng_rq_redis_socket_timeout: Optional[float] = None  # Socket timeout in seconds
     eng_rq_redis_socket_connect_timeout: Optional[float] = (

--- a/tests/test_failure_ttl.py
+++ b/tests/test_failure_ttl.py
@@ -1,0 +1,20 @@
+"""Tests for RQ failure_ttl configuration in docling-serve."""
+
+from docling_serve.settings import DoclingServeSettings
+
+
+class TestFailureTTLSettings:
+    def test_default_failure_ttl_matches_results_ttl(self):
+        settings = DoclingServeSettings(
+            eng_rq_redis_url="redis://localhost:6379/",
+        )
+        assert settings.eng_rq_failure_ttl == settings.eng_rq_results_ttl
+        assert settings.eng_rq_failure_ttl == 3_600 * 4
+
+    def test_failure_ttl_is_configurable(self):
+        settings = DoclingServeSettings(
+            eng_rq_redis_url="redis://localhost:6379/",
+            eng_rq_failure_ttl=7200,
+        )
+        assert settings.eng_rq_failure_ttl == 7200
+        assert settings.eng_rq_results_ttl == 3_600 * 4


### PR DESCRIPTION
## Summary

- Add `eng_rq_failure_ttl` setting (default: 4h, matching `eng_rq_results_ttl`)
- Pass through to `RQOrchestratorConfig` in both `orchestrator_factory.py` and `__main__.py`
- Pass `failure_ttl` on `enqueue()` in `RedisAwareRQOrchestrator` for the instrumented job path
- Without this, RQ uses its default of **1 year** for failed jobs, causing unbounded Redis memory growth

## Changes

| File | Change |
|------|--------|
| `settings.py` | New: `eng_rq_failure_ttl: int = 3_600 * 4` |
| `orchestrator_factory.py` | Pass `failure_ttl=` to `RQOrchestratorConfig` and `enqueue()` |
| `__main__.py` | Pass `failure_ttl=` to `RQOrchestratorConfig` for worker startup |

## Test plan

- [x] `tests/test_failure_ttl.py` - settings defaults and configurability
- [x] Existing tests unaffected
- [ ] Live test: deploy, verify `ZCARD rq:failed:convert` stops growing

## Configuration

| Env var | Default | Description |
|---------|---------|-------------|
| `DOCLING_SERVE_ENG_RQ_FAILURE_TTL` | `14400` (4h) | Time-to-live for failed RQ jobs in Redis |

## Companion PR

docling-jobkit: `fix/rq-failure-ttl` (https://github.com/docling-project/docling-jobkit/pull/101) - adds `failure_ttl` field to `RQOrchestratorConfig`, passes to `Queue()` and `enqueue()`


**Issue resolved by this Pull Request:**
Resolves #518 
