### PR TITLE
feat: ready endpoint for API pods

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -13,6 +13,7 @@ from io import BytesIO
 from typing import Annotated
 
 import psutil
+import redis.asyncio
 from fastapi import (
     BackgroundTasks,
     Depends,
@@ -78,6 +79,7 @@ from docling_serve.datamodel.responses import (
     HealthCheckResponse,
     MessageKind,
     PresignedUrlConvertDocumentResponse,
+    ReadinessResponse,
     TaskStatusResponse,
     WebsocketMessage,
 )
@@ -124,6 +126,11 @@ for handler in root_logger.handlers:  # Iterate through existing handlers
 
 _log = logging.getLogger(__name__)
 
+# Tracks whether warm_up_caches() has completed.  Meaningful only for the
+# LocalOrchestrator (which eagerly loads ML models); the RQ orchestrator's
+# implementation is a no-op so this event fires instantly in RQ deployments.
+_models_ready = asyncio.Event()
+
 
 # Context manager to initialize and clean up the lifespan of the FastAPI app
 @asynccontextmanager
@@ -134,9 +141,12 @@ async def lifespan(app: FastAPI):
     notifier = WebsocketNotifier(orchestrator)
     orchestrator.bind_notifier(notifier)
 
-    # Warm up processing cache
+    # Warm up processing cache (loads ML models for LocalOrchestrator;
+    # no-op for RQOrchestrator since models live in the worker pods).
     if docling_serve_settings.load_models_at_boot:
         await orchestrator.warm_up_caches()
+
+    _models_ready.set()
 
     # Start the background queue processor
     queue_task = asyncio.create_task(orchestrator.process_queue())
@@ -478,8 +488,46 @@ def create_app():  # noqa: C901
         response = RedirectResponse(url=logo_url)
         return response
 
+    async def _check_redis() -> bool:
+        orchestrator = get_async_orchestrator()
+        if not hasattr(orchestrator, "_redis_pool"):
+            return True
+        try:
+            conn = redis.asyncio.Redis(connection_pool=orchestrator._redis_pool)
+            await conn.ping()  # type: ignore[misc]
+            return True
+        except Exception:
+            _log.exception("Redis readiness check failed")
+            return False
+
     @app.get("/health", tags=["health"])
     def health() -> HealthCheckResponse:
+        return HealthCheckResponse()
+
+    @app.get("/ready", tags=["health"])
+    async def readiness() -> ReadinessResponse:
+        # Gate on model loading (LocalOrchestrator only; instant for RQ).
+        if not _models_ready.is_set():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Models not yet loaded",
+            )
+
+        if docling_serve_settings.eng_kind == AsyncEngine.RQ:
+            if not await _check_redis():
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail="Redis connection failed",
+                )
+
+        return ReadinessResponse()
+
+    @app.get("/readyz", tags=["health"], include_in_schema=False)
+    async def readyz() -> ReadinessResponse:
+        return await readiness()
+
+    @app.get("/livez", tags=["health"], include_in_schema=False)
+    def livez() -> HealthCheckResponse:
         return HealthCheckResponse()
 
     # API readiness compatibility for OpenShift AI Workbench

--- a/docling_serve/datamodel/responses.py
+++ b/docling_serve/datamodel/responses.py
@@ -18,6 +18,10 @@ class HealthCheckResponse(BaseModel):
     status: str = "ok"
 
 
+class ReadinessResponse(BaseModel):
+    status: str = "ok"
+
+
 class ClearResponse(BaseModel):
     status: str = "ok"
 

--- a/docling_serve/otel_instrumentation.py
+++ b/docling_serve/otel_instrumentation.py
@@ -23,7 +23,7 @@ from docling_serve.rq_metrics_collector import RQCollector
 logger = logging.getLogger(__name__)
 
 
-FILTERED_PATHS = {"/metrics", "/health", "/healthz", "/readyz", "/livez"}
+FILTERED_PATHS = {"/metrics", "/health", "/healthz", "/ready", "/readyz", "/livez"}
 
 
 class HealthMetricsFilterSampler(Sampler):

--- a/docs/deploy-examples/docling-serve-oauth.yaml
+++ b/docs/deploy-examples/docling-serve-oauth.yaml
@@ -89,14 +89,22 @@ spec:
             requests:
               cpu: 800m
               memory: 1Gi
-          readinessProbe:
+          startupProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: http
               scheme: HTTPS
-            initialDelaySeconds: 10
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 30
             timeoutSeconds: 2
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+              scheme: HTTPS
             periodSeconds: 5
+            timeoutSeconds: 2
             successThreshold: 1
             failureThreshold: 3
           livenessProbe:

--- a/tests/test_health_probes.py
+++ b/tests/test_health_probes.py
@@ -1,0 +1,85 @@
+import asyncio
+
+import pytest
+import pytest_asyncio
+from asgi_lifespan import LifespanManager
+from httpx import ASGITransport, AsyncClient
+
+from docling_serve.app import _models_ready, create_app
+from docling_serve.datamodel.responses import (
+    HealthCheckResponse,
+    ReadinessResponse,
+)
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    return asyncio.get_event_loop()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def app():
+    app = create_app()
+    async with LifespanManager(app) as manager:
+        yield manager.app
+
+
+@pytest_asyncio.fixture(scope="session")
+async def client(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://app.io"
+    ) as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_health(client: AsyncClient):
+    response = await client.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_ready(client: AsyncClient):
+    response = await client.get("/ready")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_readyz_alias(client: AsyncClient):
+    response = await client.get("/readyz")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_livez_alias(client: AsyncClient):
+    response = await client.get("/livez")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_ready_returns_503_when_models_not_loaded(client: AsyncClient):
+    _models_ready.clear()
+    try:
+        response = await client.get("/ready")
+        assert response.status_code == 503
+        assert "Models not yet loaded" in response.json()["detail"]
+    finally:
+        _models_ready.set()
+
+
+def test_health_check_response_model():
+    resp = HealthCheckResponse()
+    assert resp.status == "ok"
+
+
+def test_readiness_response_model():
+    resp = ReadinessResponse()
+    assert resp.status == "ok"


### PR DESCRIPTION
**Description**

Adds a `GET /ready` endpoint that returns 200 when the pod is genuinely ready to serve:

- **LocalOrchestrator:** gates on `warm_up_caches()` completion (ML model loading)
- **RQOrchestrator:** gates on Redis connectivity (`PING` against the connection pool)
- Returns 503 with a descriptive `detail` message when not ready

Also adds `/readyz` (alias) and `/livez` (lightweight liveness, equivalent to `/health`) for Kubernetes convention compatibility.

The existing `load_models_at_boot` setting already controls whether `warm_up_caches()` runs. The readiness gate respects this - if models are loaded at boot, the pod isn't ready until they finish; if not, the gate passes immediately.

**Architecture note:** In RQ deployments, `warm_up_caches()` is a no-op on the API pod (models live in worker pods). The readiness gate fires instantly and only the Redis check is meaningful. The model-loading gate exists for LocalOrchestrator users who run conversion in-process.

Updated the OpenShift deploy example to use:
- `startupProbe` → `/ready` (allows slow model loading without killing the pod)
- `readinessProbe` → `/ready` (gates traffic on actual readiness)
- `livenessProbe` → `/health` (lightweight, doesn't check dependencies)


**Impact**

| Deployment type | Benefit |
|-----------------|---------|
| LocalOrchestrator | Prevents traffic before models load - eliminates timeout errors during rollouts |
| RQOrchestrator | Prevents traffic before Redis is reachable - eliminates connection errors during rollouts |

**Issue resolved by this Pull Request:**
Resolves #537 
