### PR TITLE
feat: add layout_model per-request option for layout analysis model selection

### DIFF
--- a/docling_serve/datamodel/convert.py
+++ b/docling_serve/datamodel/convert.py
@@ -1,8 +1,18 @@
 # Define the input options for the API
-from typing import Annotated
+from typing import Annotated, Optional
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
+from docling.datamodel.layout_model_specs import (
+    DOCLING_LAYOUT_EGRET_LARGE,
+    DOCLING_LAYOUT_EGRET_MEDIUM,
+    DOCLING_LAYOUT_EGRET_XLARGE,
+    DOCLING_LAYOUT_HERON,
+    DOCLING_LAYOUT_HERON_101,
+    DOCLING_LAYOUT_V2,
+    LayoutModelConfig,
+    LayoutModelType,
+)
 from docling.datamodel.pipeline_options import (
     EasyOcrOptions,
 )
@@ -15,6 +25,21 @@ ocr_factory = get_ocr_factory(
     allow_external_plugins=docling_serve_settings.allow_external_plugins
 )
 ocr_engines_enum = ocr_factory.get_enum()
+
+LAYOUT_MODEL_SPECS: dict[LayoutModelType, LayoutModelConfig] = {
+    LayoutModelType.DOCLING_LAYOUT_HERON: DOCLING_LAYOUT_HERON,
+    LayoutModelType.DOCLING_LAYOUT_HERON_101: DOCLING_LAYOUT_HERON_101,
+    LayoutModelType.DOCLING_LAYOUT_EGRET_MEDIUM: DOCLING_LAYOUT_EGRET_MEDIUM,
+    LayoutModelType.DOCLING_LAYOUT_EGRET_LARGE: DOCLING_LAYOUT_EGRET_LARGE,
+    LayoutModelType.DOCLING_LAYOUT_EGRET_XLARGE: DOCLING_LAYOUT_EGRET_XLARGE,
+    LayoutModelType.DOCLING_LAYOUT_V2: DOCLING_LAYOUT_V2,
+}
+
+_default_layout_model: Optional[LayoutModelType] = None
+if docling_serve_settings.default_layout_model:
+    _default_layout_model = LayoutModelType(
+        docling_serve_settings.default_layout_model
+    )
 
 
 class ConvertDocumentsRequestOptions(ConvertDocumentsOptions):
@@ -30,6 +55,23 @@ class ConvertDocumentsRequestOptions(ConvertDocumentsOptions):
         ),
     ] = ocr_engines_enum(EasyOcrOptions.kind)  # type: ignore
 
+    layout_model: Annotated[
+        Optional[LayoutModelType],
+        Field(
+            description=(
+                "The layout analysis model to use. String. "
+                f"Allowed values: {', '.join([v.value for v in LayoutModelType])}. "
+                "Optional, defaults to docling_layout_heron. "
+                "When set, expands into layout_custom_config automatically. "
+                "Ignored if layout_custom_config is explicitly provided."
+            ),
+            examples=[
+                LayoutModelType.DOCLING_LAYOUT_HERON.value,
+                LayoutModelType.DOCLING_LAYOUT_EGRET_LARGE.value,
+            ],
+        ),
+    ] = _default_layout_model
+
     document_timeout: Annotated[
         float,
         Field(
@@ -38,3 +80,19 @@ class ConvertDocumentsRequestOptions(ConvertDocumentsOptions):
             le=docling_serve_settings.max_document_timeout,
         ),
     ] = docling_serve_settings.max_document_timeout
+
+    @model_validator(mode="before")
+    @classmethod
+    def expand_layout_model(cls, data: dict) -> dict:
+        if not isinstance(data, dict):
+            return data
+        layout_model = data.get("layout_model")
+        layout_custom_config = data.get("layout_custom_config")
+        if layout_model is not None and layout_custom_config is None:
+            model_type = LayoutModelType(layout_model)
+            spec = LAYOUT_MODEL_SPECS[model_type]
+            data["layout_custom_config"] = {
+                "kind": "docling_layout_default",
+                "model_spec": spec.model_dump(mode="json"),
+            }
+        return data

--- a/docling_serve/gradio_ui.py
+++ b/docling_serve/gradio_ui.py
@@ -15,6 +15,7 @@ import gradio as gr
 import httpx
 
 from docling.datamodel.base_models import FormatToExtensions
+from docling.datamodel.layout_model_specs import LayoutModelType
 from docling.datamodel.pipeline_options import (
     PdfBackend,
     ProcessingPipeline,
@@ -356,6 +357,7 @@ def process_url(
     force_ocr,
     ocr_engine,
     ocr_lang,
+    layout_model,
     pdf_backend,
     table_mode,
     abort_on_error,
@@ -366,26 +368,29 @@ def process_url(
     do_picture_description,
 ):
     target = {"kind": "zip" if return_as_file else "inbody"}
+    options = {
+        "to_formats": to_formats,
+        "image_export_mode": image_export_mode,
+        "pipeline": pipeline,
+        "ocr": ocr,
+        "force_ocr": force_ocr,
+        "ocr_engine": ocr_engine,
+        "ocr_lang": _to_list_of_strings(ocr_lang),
+        "pdf_backend": pdf_backend,
+        "table_mode": table_mode,
+        "abort_on_error": abort_on_error,
+        "do_code_enrichment": do_code_enrichment,
+        "do_formula_enrichment": do_formula_enrichment,
+        "do_picture_classification": do_picture_classification,
+        "do_picture_description": do_picture_description,
+    }
+    if layout_model:
+        options["layout_model"] = layout_model
     parameters = {
         "sources": [
             {"kind": "http", "url": source} for source in input_sources.split(",")
         ],
-        "options": {
-            "to_formats": to_formats,
-            "image_export_mode": image_export_mode,
-            "pipeline": pipeline,
-            "ocr": ocr,
-            "force_ocr": force_ocr,
-            "ocr_engine": ocr_engine,
-            "ocr_lang": _to_list_of_strings(ocr_lang),
-            "pdf_backend": pdf_backend,
-            "table_mode": table_mode,
-            "abort_on_error": abort_on_error,
-            "do_code_enrichment": do_code_enrichment,
-            "do_formula_enrichment": do_formula_enrichment,
-            "do_picture_classification": do_picture_classification,
-            "do_picture_description": do_picture_description,
-        },
+        "options": options,
         "target": target,
     }
     if (
@@ -438,6 +443,7 @@ def process_file(
     force_ocr,
     ocr_engine,
     ocr_lang,
+    layout_model,
     pdf_backend,
     table_mode,
     abort_on_error,
@@ -456,25 +462,28 @@ def process_file(
     ]
     target = {"kind": "zip" if return_as_file else "inbody"}
 
+    options = {
+        "to_formats": to_formats,
+        "image_export_mode": image_export_mode,
+        "pipeline": pipeline,
+        "ocr": ocr,
+        "force_ocr": force_ocr,
+        "ocr_engine": ocr_engine,
+        "ocr_lang": _to_list_of_strings(ocr_lang),
+        "pdf_backend": pdf_backend,
+        "table_mode": table_mode,
+        "abort_on_error": abort_on_error,
+        "return_as_file": return_as_file,
+        "do_code_enrichment": do_code_enrichment,
+        "do_formula_enrichment": do_formula_enrichment,
+        "do_picture_classification": do_picture_classification,
+        "do_picture_description": do_picture_description,
+    }
+    if layout_model:
+        options["layout_model"] = layout_model
     parameters = {
         "sources": files_data,
-        "options": {
-            "to_formats": to_formats,
-            "image_export_mode": image_export_mode,
-            "pipeline": pipeline,
-            "ocr": ocr,
-            "force_ocr": force_ocr,
-            "ocr_engine": ocr_engine,
-            "ocr_lang": _to_list_of_strings(ocr_lang),
-            "pdf_backend": pdf_backend,
-            "table_mode": table_mode,
-            "abort_on_error": abort_on_error,
-            "return_as_file": return_as_file,
-            "do_code_enrichment": do_code_enrichment,
-            "do_formula_enrichment": do_formula_enrichment,
-            "do_picture_classification": do_picture_classification,
-            "do_picture_description": do_picture_description,
-        },
+        "options": options,
         "target": target,
     }
 
@@ -717,6 +726,15 @@ with gr.Blocks(
                 )
             ocr_engine.change(change_ocr_lang, inputs=[ocr_engine], outputs=[ocr_lang])
         with gr.Row():
+            with gr.Column(scale=1):
+                layout_model = gr.Radio(
+                    [("Default", "")] + [
+                        (v.value, v.value) for v in LayoutModelType
+                    ],
+                    label="Layout Model",
+                    value="",
+                )
+        with gr.Row():
             with gr.Column(scale=4):
                 pdf_backend = gr.Radio(
                     [v.value for v in (PdfBackend.DOCLING_PARSE, PdfBackend.PYPDFIUM2)],
@@ -833,6 +851,7 @@ with gr.Blocks(
             force_ocr,
             ocr_engine,
             ocr_lang,
+            layout_model,
             pdf_backend,
             table_mode,
             abort_on_error,
@@ -921,6 +940,7 @@ with gr.Blocks(
             force_ocr,
             ocr_engine,
             ocr_lang,
+            layout_model,
             pdf_backend,
             table_mode,
             abort_on_error,

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -69,6 +69,8 @@ class DoclingServeSettings(BaseSettings):
     max_num_pages: int = sys.maxsize
     max_file_size: int = sys.maxsize
 
+    default_layout_model: Optional[str] = None
+
     # Threading pipeline
     queue_max_size: Optional[int] = None
     ocr_batch_size: Optional[int] = None

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,7 @@ THe following table describes the options to configure the Docling Serve app.
 |  | `DOCLING_SERVE_ALLOW_CUSTOM_VLM_CONFIG` | `false` | Allow users to specify a fully custom VLM pipeline configuration (`vlm_pipeline_custom_config`). When `false`, only presets are accepted. |
 |  | `DOCLING_SERVE_ALLOW_CUSTOM_PICTURE_DESCRIPTION_CONFIG` | `false` | Allow users to specify a fully custom picture description configuration. When `false`, only presets are accepted. |
 |  | `DOCLING_SERVE_ALLOW_CUSTOM_CODE_FORMULA_CONFIG` | `false` | Allow users to specify a fully custom code/formula configuration. When `false`, only presets are accepted. |
+|  | `DOCLING_SERVE_DEFAULT_LAYOUT_MODEL` | unset | Default layout analysis model for all requests. Allowed values: `docling_layout_heron`, `docling_layout_heron_101`, `docling_layout_egret_medium`, `docling_layout_egret_large`, `docling_layout_egret_xlarge`, `docling_layout_v2`. When unset, docling's built-in default (heron) is used. Can be overridden per-request via the `layout_model` option. |
 |  | `DOCLING_SERVE_SINGLE_USE_RESULTS` | `true` | If true, results can be accessed only once. If false, the results accumulate in the scratch directory. |
 |  | `DOCLING_SERVE_RESULT_REMOVAL_DELAY` | `300` | When `DOCLING_SERVE_SINGLE_USE_RESULTS` is active, this is the delay before results are removed from the task registry. |
 |  | `DOCLING_SERVE_MAX_DOCUMENT_TIMEOUT` | `604800` (7 days) | The maximum time for processing a document. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,7 +47,8 @@ On top of the source of file (see below), both endpoints support the same parame
 | `picture_description_custom_config` | PictureDescriptionVlmEngineOptions or dict or NoneType | Custom picture description configuration including model spec and engine options. |
 | `code_formula_custom_config` | CodeFormulaVlmOptions or dict or NoneType | Custom code/formula extraction configuration including model spec and engine options. |
 | `table_structure_custom_config` | Dict[str, Any] or NoneType | Custom configuration for table structure model. Use this to specify a non-default kind with its options. The 'kind' field in the config dict determines which table structure implementation to use. If not specified, uses the default kind with preset configuration. |
-| `layout_custom_config` | Dict[str, Any] or NoneType | Custom configuration for layout model. Use this to specify a non-default kind with its options. The 'kind' field in the config dict determines which layout implementation to use. If not specified, uses the default kind with preset configuration. |
+| `layout_model` | LayoutModelType or NoneType | The layout analysis model to use. Allowed values: `docling_layout_heron`, `docling_layout_heron_101`, `docling_layout_egret_medium`, `docling_layout_egret_large`, `docling_layout_egret_xlarge`, `docling_layout_v2`. Optional. When set, automatically expands into `layout_custom_config`. Ignored if `layout_custom_config` is explicitly provided. |
+| `layout_custom_config` | Dict[str, Any] or NoneType | Custom configuration for layout model. Use this to specify a non-default kind with its options. The 'kind' field in the config dict determines which layout implementation to use. If not specified, uses the default kind with preset configuration. Takes precedence over `layout_model`. |
 
 <h4>CodeFormulaVlmOptions</h4>
 
@@ -192,6 +193,7 @@ Simple payload example:
     "force_ocr": false,
     "ocr_engine": "easyocr",
     "ocr_lang": ["en"],
+    "layout_model": "docling_layout_heron",
     "pdf_backend": "dlparse_v2",
     "table_mode": "fast",
     "abort_on_error": false,

--- a/tests/test_layout_model.py
+++ b/tests/test_layout_model.py
@@ -1,0 +1,57 @@
+import pytest
+
+from docling.datamodel.layout_model_specs import LayoutModelType
+
+from docling_serve.datamodel.convert import (
+    LAYOUT_MODEL_SPECS,
+    ConvertDocumentsRequestOptions,
+)
+
+
+class TestLayoutModelExpansion:
+    """Test that the layout_model field correctly expands into layout_custom_config."""
+
+    def test_layout_model_expands_to_custom_config(self):
+        opts = ConvertDocumentsRequestOptions(
+            layout_model=LayoutModelType.DOCLING_LAYOUT_EGRET_LARGE,
+        )
+        assert opts.layout_custom_config is not None
+        assert opts.layout_custom_config["kind"] == "docling_layout_default"
+        spec = opts.layout_custom_config["model_spec"]
+        assert spec["name"] == "docling_layout_egret_large"
+        assert "docling-project" in spec["repo_id"]
+
+    def test_layout_model_all_types_expand(self):
+        for model_type in LayoutModelType:
+            opts = ConvertDocumentsRequestOptions(layout_model=model_type)
+            assert opts.layout_custom_config is not None
+            expected_spec = LAYOUT_MODEL_SPECS[model_type].model_dump(mode="json")
+            assert opts.layout_custom_config["model_spec"] == expected_spec
+
+    def test_layout_custom_config_takes_precedence(self):
+        custom_config = {
+            "kind": "custom_layout_model",
+            "model_path": "/my/custom/model",
+        }
+        opts = ConvertDocumentsRequestOptions(
+            layout_model=LayoutModelType.DOCLING_LAYOUT_EGRET_LARGE,
+            layout_custom_config=custom_config,
+        )
+        assert opts.layout_custom_config == custom_config
+
+    def test_layout_model_none_leaves_config_unset(self):
+        opts = ConvertDocumentsRequestOptions(layout_model=None)
+        assert opts.layout_custom_config is None
+
+    def test_layout_model_string_value_accepted(self):
+        opts = ConvertDocumentsRequestOptions(
+            **{"layout_model": "docling_layout_heron"}
+        )
+        assert opts.layout_custom_config is not None
+        assert opts.layout_custom_config["model_spec"]["name"] == "docling_layout_heron"
+
+    def test_invalid_layout_model_rejected(self):
+        with pytest.raises(ValueError):
+            ConvertDocumentsRequestOptions(
+                **{"layout_model": "nonexistent_model"}
+            )


### PR DESCRIPTION
Closes #541

## Summary

- Adds a `layout_model` enum field to `ConvertDocumentsRequestOptions`, mirroring the existing `ocr_engine` pattern, so users can select between docling's 6 layout analysis models (`docling_layout_heron`, `docling_layout_heron_101`, `docling_layout_egret_medium`, `docling_layout_egret_large`, `docling_layout_egret_xlarge`, `docling_layout_v2`) without manually constructing verbose `layout_custom_config` dicts.
- A `@model_validator(mode="before")` expands `layout_model` into the existing `layout_custom_config` dict, so no changes to `docling_jobkit` are needed. When `layout_custom_config` is explicitly provided, it takes precedence.
- Adds `DOCLING_SERVE_DEFAULT_LAYOUT_MODEL` env var for setting a server-wide default.
- Adds a Layout Model radio selector to the Gradio UI.

## Motivation

The docling library supports 6 layout models via `LayoutOptions.model_spec`, but docling-serve had no ergonomic way to choose between them per-request. Users had to either accept the default or construct a raw `layout_custom_config` dict (undiscoverable, verbose). This change makes layout model selection a first-class option, consistent with how `ocr_engine` already works.

## Changes

| File | Change |
|------|--------|
| `docling_serve/settings.py` | Add `default_layout_model` setting |
| `docling_serve/datamodel/convert.py` | Add `layout_model` field, `LAYOUT_MODEL_SPECS` mapping, and expansion validator |
| `docling_serve/gradio_ui.py` | Add Layout Model radio to Options, wire into process functions |
| `docs/configuration.md` | Document `DOCLING_SERVE_DEFAULT_LAYOUT_MODEL` env var |
| `docs/usage.md` | Document `layout_model` parameter |
| `tests/test_layout_model.py` | 6 unit tests for expansion, precedence, and validation |

## Test plan

- [x] `uv run pytest tests/test_layout_model.py` — all 6 tests pass
- [ ] Manual: start server, send request with `"layout_model": "docling_layout_egret_large"` in options, confirm accepted
- [ ] Confirm `layout_custom_config` still works and takes precedence when both are set

🤖 Generated with [Claude Code](https://claude.com/claude-code)