### PR TITLE
fix: use UVICORN_ROOT_PATH as root_path for FastAPI app

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -207,7 +207,7 @@ def create_app():  # noqa: C901
         title="Docling Serve",
         docs_url=None if offline_docs_assets else "/swagger",
         redoc_url=None if offline_docs_assets else "/docs",
-        root_path=uvicorn_settings.root_path or "",
+        root_path=uvicorn_settings.root_path,
         lifespan=lifespan,
         version=version,
     )


### PR DESCRIPTION
**Description of the changes:**
This should fix the issue described here: https://github.com/docling-project/docling-serve/issues/485
The root path specified by the user as `UVICORN_ROOT_PATH` shall be used when instantiating the `fastapi.FastAPI` app.

**Issue resolved by this Pull Request:**
Resolves #485
