### PR TITLE
feat: add PRELOAD_PIPELINES setting for format-level model pre-warming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,18 @@ UVICORN_RELOAD=True
 # DOCLING_SERVE_CONFIG_FILE=examples/config.yaml
 
 # ============================================================================
+# Pipeline Pre-loading
+# ============================================================================
+# Pre-load ML pipelines at boot time to keep models resident in GPU/CPU memory.
+# Eliminates cold-start latency on the first request for configured formats.
+# "pdf" is always included. Requires DOCLING_SERVE_LOAD_MODELS_AT_BOOT=true.
+# Valid formats: any InputFormat name (e.g., pdf, image, audio)
+# JSON format:
+# DOCLING_SERVE_PRELOAD_PIPELINES='["pdf", "audio"]'
+# Comma-separated format:
+# DOCLING_SERVE_PRELOAD_PIPELINES=pdf,audio
+
+# ============================================================================
 # VLM Pipeline Control
 # ============================================================================
 # Default VLM preset to use when user specifies "default"

--- a/docling_serve/__main__.py
+++ b/docling_serve/__main__.py
@@ -450,6 +450,12 @@ def rq_worker() -> Any:
         # Layout Control
         default_layout_kind=docling_serve_settings.default_layout_kind,
         allowed_layout_kinds=docling_serve_settings.allowed_layout_kinds,
+        # Pipeline Pre-loading (only when load_models_at_boot is enabled)
+        preload_formats=(
+            list(docling_serve_settings.preload_pipelines or [])
+            if docling_serve_settings.load_models_at_boot
+            else []
+        ),
     )
 
     # Create worker with instrumentation

--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -143,6 +143,9 @@ async def lifespan(app: FastAPI):
 
     # Warm up processing cache (loads ML models for LocalOrchestrator;
     # no-op for RQOrchestrator since models live in the worker pods).
+    # Additional pipelines configured via preload_pipelines are warmed
+    # by docling-jobkit's preload_additional_formats() in warm_up_caches()
+    # and in each worker's startup.
     if docling_serve_settings.load_models_at_boot:
         await orchestrator.warm_up_caches()
 

--- a/docling_serve/orchestrator_factory.py
+++ b/docling_serve/orchestrator_factory.py
@@ -454,6 +454,12 @@ def get_async_orchestrator() -> BaseOrchestrator:
             # Layout Control
             default_layout_kind=docling_serve_settings.default_layout_kind,
             allowed_layout_kinds=docling_serve_settings.allowed_layout_kinds,
+            # Pipeline Pre-loading (only when load_models_at_boot is enabled)
+            preload_formats=(
+                list(docling_serve_settings.preload_pipelines or [])
+                if docling_serve_settings.load_models_at_boot
+                else []
+            ),
         )
         cm = DoclingConverterManager(config=cm_config)
 

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -102,6 +102,7 @@ class DoclingServeSettings(BaseSettings):
     single_use_results: bool = True
     result_removal_delay: float = 300  # 5 minutes
     load_models_at_boot: bool = True
+    preload_pipelines: Optional[list[str]] = None
     options_cache_size: int = 2
     enable_remote_services: bool = False
     allow_external_plugins: bool = False
@@ -250,6 +251,7 @@ class DoclingServeSettings(BaseSettings):
         "allowed_code_formula_engines",
         "allowed_table_structure_kinds",
         "allowed_layout_kinds",
+        "preload_pipelines",
         mode="before",
     )
     @classmethod
@@ -298,6 +300,15 @@ class DoclingServeSettings(BaseSettings):
         if self.eng_kind == AsyncEngine.RQ:
             if not self.eng_rq_redis_url:
                 raise ValueError("RQ Redis url is required when using the RQ engine.")
+
+        # Normalize preload_pipelines: default to ["pdf"], lowercase,
+        # and ensure "pdf" is always present.
+        if not self.preload_pipelines:
+            self.preload_pipelines = ["pdf"]
+        else:
+            self.preload_pipelines = [p.lower() for p in self.preload_pipelines]
+            if "pdf" not in self.preload_pipelines:
+                self.preload_pipelines.insert(0, "pdf")
 
         return self
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,7 @@ THe following table describes the options to configure the Docling Serve app.
 |  | `DOCLING_SERVE_SYNC_POLL_INTERVAL` | `2` | Number of seconds to sleep between polling the task status in the sync endpoints. |
 |  | `DOCLING_SERVE_MAX_SYNC_WAIT` | `120` | Max number of seconds a synchronous endpoint is waiting for the task completion. |
 |  | `DOCLING_SERVE_LOAD_MODELS_AT_BOOT` | `True` | If enabled, the models for the default options will be loaded at boot. |
+|  | `DOCLING_SERVE_PRELOAD_PIPELINES` | `null` (normalized to `["pdf"]`) | List of input-format pipelines to eagerly initialize at startup. Accepts JSON array (`'["pdf", "audio"]'`) or comma-separated string (`pdf,audio`). `"pdf"` is always included. Requires `LOAD_MODELS_AT_BOOT=true`. See [Pipeline Pre-loading](#pipeline-pre-loading) below. |
 |  | `DOCLING_SERVE_OPTIONS_CACHE_SIZE` | `2` | How many DocumentConveter objects (including their loaded models) to keep in the cache. |
 |  | `DOCLING_SERVE_QUEUE_MAX_SIZE` | | Size of the pages queue. Potentially so many pages opened at the same time. |
 |  | `DOCLING_SERVE_OCR_BATCH_SIZE` | | Batch size for the OCR stage. |
@@ -124,6 +125,36 @@ The following options control the behavior of the Docling converter, including p
 | ----|---------|-------------|
 | `DOCLING_SERVE_DEFAULT_LAYOUT_KIND` | `docling_layout_default` | Default layout kind used when user doesn't provide custom config. |
 | `DOCLING_SERVE_ALLOWED_LAYOUT_KINDS` | `null` (all allowed) | List of allowed layout kinds. The default kind is always implicitly allowed. Accepts JSON array or comma-separated string. Use this to block specific plugin kinds for security or policy reasons. |
+
+#### Pipeline Pre-loading
+
+The `DOCLING_SERVE_PRELOAD_PIPELINES` setting controls which ML pipelines are eagerly
+loaded at startup, keeping models resident in GPU/CPU memory and eliminating cold-start
+latency on the first request for each configured format.
+
+| ENV | Default | Description |
+| ----|---------|-------------|
+| `DOCLING_SERVE_PRELOAD_PIPELINES` | `null` (normalized to `["pdf"]`) | List of `InputFormat` names to pre-warm. Accepts JSON array or comma-separated string. `"pdf"` is always included automatically. Only takes effect when `DOCLING_SERVE_LOAD_MODELS_AT_BOOT=true`. |
+
+**Example** — pre-load both the PDF pipeline and the ASR/Whisper pipeline:
+```bash
+DOCLING_SERVE_PRELOAD_PIPELINES='["pdf", "audio"]'
+# or equivalently:
+DOCLING_SERVE_PRELOAD_PIPELINES=pdf,audio
+```
+
+**Topology behavior:**
+
+| Engine | `ENG_LOC_SHARE_MODELS` | Where pre-warming happens |
+|--------|------------------------|--------------------------|
+| Local | `true` | On the shared converter manager in `warm_up_caches()`. Workers reuse it. |
+| Local | `false` (default) | On the orchestrator's manager at boot (for config validation and readiness gating), then on each worker's own converter manager at startup. |
+| RQ | N/A | On each RQ worker's converter manager at process startup. |
+
+> [!NOTE]
+> `DOCLING_SERVE_PRELOAD_PIPELINES` covers format-level pipelines (e.g. `pdf`, `audio`, `image`).
+> Option-level variants such as VLM, picture description, and code/formula enrichment models are
+> selected per-request and are not covered by this setting.
 
 **Configuration Examples:**
 

--- a/tests/test_env_parsing.py
+++ b/tests/test_env_parsing.py
@@ -51,3 +51,81 @@ def test_default_values():
 
     assert settings.allowed_vlm_presets is None
     assert settings.custom_vlm_presets == {}
+
+    # preload_pipelines defaults to None, normalized to ["pdf"] by model validator
+    assert settings.preload_pipelines == ["pdf"]
+
+
+def test_preload_pipelines_from_json_array(monkeypatch):
+    """Test parsing preload_pipelines from JSON array."""
+    monkeypatch.setenv("DOCLING_SERVE_PRELOAD_PIPELINES", '["pdf", "audio"]')
+
+    settings = DoclingServeSettings()
+    assert settings.preload_pipelines == ["pdf", "audio"]
+
+
+def test_preload_pipelines_from_csv(monkeypatch):
+    """Test parsing preload_pipelines from comma-separated string."""
+    monkeypatch.setenv("DOCLING_SERVE_PRELOAD_PIPELINES", "pdf,audio")
+
+    settings = DoclingServeSettings()
+    assert settings.preload_pipelines == ["pdf", "audio"]
+
+
+def test_preload_pipelines_lowercased(monkeypatch):
+    """Test that preload_pipelines values are lowercased."""
+    monkeypatch.setenv("DOCLING_SERVE_PRELOAD_PIPELINES", '["PDF", "AUDIO"]')
+
+    settings = DoclingServeSettings()
+    assert settings.preload_pipelines == ["pdf", "audio"]
+
+
+def test_preload_pipelines_always_includes_pdf(monkeypatch):
+    """Test that pdf is always included in preload_pipelines."""
+    monkeypatch.setenv("DOCLING_SERVE_PRELOAD_PIPELINES", '["audio"]')
+
+    settings = DoclingServeSettings()
+    assert "pdf" in settings.preload_pipelines
+    assert "audio" in settings.preload_pipelines
+
+
+def test_preload_pipelines_yaml_config(monkeypatch):
+    """Test loading preload_pipelines from YAML config file."""
+    import tempfile
+    from pathlib import Path
+
+    import yaml
+
+    config_data = {"preload_pipelines": ["pdf", "audio"]}
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump(config_data, f)
+        config_path = f.name
+
+    try:
+        monkeypatch.setenv("DOCLING_SERVE_CONFIG_FILE", config_path)
+        settings = DoclingServeSettings()
+        assert settings.preload_pipelines == ["pdf", "audio"]
+    finally:
+        Path(config_path).unlink()
+
+
+def test_preload_pipelines_gated_by_load_models_at_boot(monkeypatch):
+    """preload_pipelines is still parsed, but the caller gates on load_models_at_boot.
+
+    The setting itself is always available (so config validation works), but
+    orchestrator_factory and __main__ pass an empty preload_formats list to
+    docling-jobkit when load_models_at_boot is False.  This test verifies
+    the setting values are independent so the gating logic can work.
+    """
+    monkeypatch.setenv("DOCLING_SERVE_LOAD_MODELS_AT_BOOT", "false")
+    monkeypatch.setenv("DOCLING_SERVE_PRELOAD_PIPELINES", '["pdf", "audio"]')
+
+    settings = DoclingServeSettings()
+    assert settings.load_models_at_boot is False
+    assert settings.preload_pipelines == ["pdf", "audio"]
+
+    # The gating logic in orchestrator_factory.py / __main__.py is:
+    # preload_formats = list(settings.preload_pipelines) if settings.load_models_at_boot else []
+    gated = list(settings.preload_pipelines) if settings.load_models_at_boot else []
+    assert gated == []


### PR DESCRIPTION
Add a `DOCLING_SERVE_PRELOAD_PIPELINES` setting that controls which ML pipelines are eagerly initialized at startup, keeping models resident in GPU/CPU memory between requests.  Defaults to `["pdf"]` (matching current behavior).  Setting it to `["pdf", "audio"]` pre-loads the Whisper ASR model alongside the standard PDF pipeline, eliminating ~5s of cold-start latency on the first audio transcription request.

The setting accepts JSON arrays or comma-separated strings, supports YAML config files, and is gated on `LOAD_MODELS_AT_BOOT=true`.  The normalized list is passed as `preload_formats` to the `DoclingConverterManagerConfig` in both the local orchestrator factory and the RQ worker startup path.

Includes documentation in `docs/configuration.md` with a topology behavior table covering local shared, local non-shared, and RQ deployment modes.

Depends on docling-jobkit `preload_formats` support (docling-project/docling-jobkit#115).

**Prerequisites for this Pull Request:**
Requires https://github.com/docling-project/docling-jobkit/pull/115
