### PR TITLE
fix: single-use result deletion via orchestrator lifecycle hooks

### DIFF
--- a/docling_serve/orchestrator_factory.py
+++ b/docling_serve/orchestrator_factory.py
@@ -416,6 +416,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             num_workers=docling_serve_settings.eng_loc_num_workers,
             shared_models=docling_serve_settings.eng_loc_share_models,
             scratch_dir=get_scratch(),
+            result_removal_delay=docling_serve_settings.result_removal_delay,
         )
 
         cm_config = DoclingConverterManagerConfig(
@@ -565,6 +566,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             redis_max_connections=docling_serve_settings.eng_rq_redis_max_connections,
             redis_socket_timeout=docling_serve_settings.eng_rq_redis_socket_timeout,
             redis_socket_connect_timeout=docling_serve_settings.eng_rq_redis_socket_connect_timeout,
+            result_removal_delay=docling_serve_settings.result_removal_delay,
         )
 
         return RedisAwareRQOrchestrator(config=rq_config)
@@ -627,6 +629,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             # Result Storage
             results_ttl=docling_serve_settings.eng_ray_results_ttl,
             results_prefix=docling_serve_settings.eng_ray_results_prefix,
+            result_removal_delay=docling_serve_settings.result_removal_delay,
             # Pub/Sub
             sub_channel=docling_serve_settings.eng_ray_sub_channel,
             # Fair Dispatcher

--- a/docling_serve/response_preparation.py
+++ b/docling_serve/response_preparation.py
@@ -1,5 +1,3 @@
-import asyncio
-import gc
 import logging
 
 from fastapi import BackgroundTasks, Response
@@ -70,15 +68,6 @@ async def prepare_response(
         raise ValueError("Unknown result type")
 
     if docling_serve_settings.single_use_results:
-
-        async def _remove_task_impl():
-            await asyncio.sleep(docling_serve_settings.result_removal_delay)
-            await orchestrator.delete_task(task_id=task_id)
-            gc.collect()
-
-        async def _remove_task():
-            asyncio.create_task(_remove_task_impl())  # noqa: RUF006
-
-        background_tasks.add_task(_remove_task)
+        background_tasks.add_task(orchestrator.on_result_fetched, task_id)
 
     return response

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -101,7 +101,6 @@ class DoclingServeSettings(BaseSettings):
     static_path: Optional[Path] = None
     scratch_path: Optional[Path] = None
     single_use_results: bool = True
-    result_removal_delay: float = 300  # 5 minutes
     load_models_at_boot: bool = True
     options_cache_size: int = 2
     enable_remote_services: bool = False
@@ -133,6 +132,7 @@ class DoclingServeSettings(BaseSettings):
     cors_headers: list[str] = ["*"]
 
     eng_kind: AsyncEngine = AsyncEngine.LOCAL
+    result_removal_delay: int = 300  # seconds until result is removed after fetch
     # Local engine
     eng_loc_num_workers: int = 2
     eng_loc_share_models: bool = False

--- a/tests/test_results_clear.py
+++ b/tests/test_results_clear.py
@@ -89,9 +89,6 @@ async def convert_file(client: AsyncClient, auth_headers: dict):
 async def test_clear_results(client: AsyncClient, auth_headers: dict):
     """Test removal of task."""
 
-    # Set long delay deletion
-    docling_serve_settings.result_removal_delay = 100
-
     # Convert and wait for completion
     task = await convert_file(client, auth_headers=auth_headers)
 
@@ -130,28 +127,34 @@ async def test_clear_results(client: AsyncClient, auth_headers: dict):
 
 @pytest.mark.asyncio
 async def test_delay_remove(client: AsyncClient, auth_headers: dict):
-    """Test automatic removal of task with delay."""
-
-    # Set short delay deletion
-    docling_serve_settings.result_removal_delay = 5
-
-    # Convert and wait for completion
-    task = await convert_file(client, auth_headers=auth_headers)
-
-    # Get result once
-    result_response = await client.get(
-        f"/v1/result/{task['task_id']}", headers=auth_headers
+    """Test automatic removal of task with delay (orchestrator-owned result_removal_delay)."""
+    from docling_serve.orchestrator_factory import (
+        get_async_orchestrator,
     )
-    assert result_response.status_code == 200, "Response should be 200 OK"
-    print("Result ok.")
-    result = result_response.json()
-    assert result["document"]["json_content"]["schema_name"] == "DoclingDocument"
 
-    print("Sleeping to wait the automatic task deletion.")
-    await asyncio.sleep(10)
+    orchestrator = get_async_orchestrator()
+    original_delay = orchestrator.config.result_removal_delay
+    orchestrator.config.result_removal_delay = 5  # 5 seconds for fast test
 
-    # Get deleted result
-    result_response = await client.get(
-        f"/v1/result/{task['task_id']}", headers=auth_headers
-    )
-    assert result_response.status_code == 404, "Response should be removed"
+    try:
+        # Convert and wait for completion
+        task = await convert_file(client, auth_headers=auth_headers)
+
+        # Fetch result — triggers on_result_fetched() which schedules deletion
+        result_response = await client.get(
+            f"/v1/result/{task['task_id']}", headers=auth_headers
+        )
+        assert result_response.status_code == 200, "Response should be 200 OK"
+        result = result_response.json()
+        assert result["document"]["json_content"]["schema_name"] == "DoclingDocument"
+
+        print("Sleeping to wait for automatic task deletion (result_removal_delay=5s).")
+        await asyncio.sleep(10)
+
+        # Result should now be gone
+        result_response = await client.get(
+            f"/v1/result/{task['task_id']}", headers=auth_headers
+        )
+        assert result_response.status_code == 404, "Result should have been removed"
+    finally:
+        orchestrator.config.result_removal_delay = original_delay


### PR DESCRIPTION
Moves result deletion from `response_preparation.py` into per-orchestrator
`on_result_fetched()` hooks. RQ and Ray use Redis `EXPIRE` (crash-safe, no sleeping
coroutines); Local uses a tracked `asyncio.create_task`.

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
