### PR TITLE
fix: support dict fields in FormDepends for multipart form data

### DIFF
--- a/docling_serve/helper_functions.py
+++ b/docling_serve/helper_functions.py
@@ -100,7 +100,9 @@ def FormDepends(
         elif is_json_field(annotation):
             annotation = str
             default = Form(
-                None if model_field.default is None else json.dumps(model_field.default),
+                None
+                if model_field.default is None
+                else json.dumps(model_field.default),
                 description=description,
                 examples=None
                 if not model_field.examples


### PR DESCRIPTION
## Problem

`FormDepends` already handles nested Pydantic model fields by accepting them as JSON strings in multipart form requests. However, plain `dict` fields (such as `layout_custom_config`) were not handled, causing a pydantic `dict_type` validation error when passed as a JSON string via the form API.

## Fix

Add `is_json_field()` to detect `dict` and `Optional[dict]` annotations, and wire it into `FormDepends` alongside the existing Pydantic model handling:

- In the parameter-building pass: expose `dict` fields as `str` form parameters (with the default serialized via `json.dumps`)
- In the parsing pass: deserialize them back with `json.loads`

## Test

Send `layout_custom_config` as a JSON string to `/v1/convert/file` via multipart form — previously failed with a pydantic validation error, now parses correctly.