### PR TITLE
fix: normalize Chinese spacing in response payloads

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -38,48 +38,25 @@ from fastapi.staticfiles import StaticFiles
 from scalar_fastapi import get_scalar_api_reference
 
 from docling.datamodel.base_models import DocumentStream
-from docling.datamodel.service.callbacks import (
+from docling_core.types.doc import ImageRefMode
+from docling_jobkit.datamodel.callback import (
     CallbackSpec,
     ProgressCallbackRequest,
     ProgressCallbackResponse,
 )
-from docling.datamodel.service.chunking import (
+from docling_jobkit.datamodel.chunking import (
     BaseChunkerOptions,
+    ChunkingExportOptions,
     HierarchicalChunkerOptions,
     HybridChunkerOptions,
 )
-from docling.datamodel.service.options import (
-    ConvertDocumentsOptions as ConvertDocumentsRequestOptions,
-)
-from docling.datamodel.service.requests import (
-    ConvertDocumentsRequest,
-    FileSourceRequest,
-    GenericChunkDocumentsRequest,
-    HttpSourceRequest,
-    S3SourceRequest,
-    TargetName,
-    TargetRequest,
-    make_request_model,
-)
-from docling.datamodel.service.responses import (
-    ChunkDocumentResponse,
-    ClearResponse,
-    ConvertDocumentResponse,
-    HealthCheckResponse,
-    MessageKind,
-    PresignedUrlConvertDocumentResponse,
-    ReadinessResponse,
-    TaskStatusResponse,
-    WebsocketMessage,
-)
-from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
-from docling.datamodel.service.targets import (
+from docling_jobkit.datamodel.http_inputs import FileSource, HttpSource
+from docling_jobkit.datamodel.s3_coords import S3Coordinates
+from docling_jobkit.datamodel.task import Task, TaskSource, TaskType
+from docling_jobkit.datamodel.task_targets import (
     InBodyTarget,
     ZipTarget,
 )
-from docling.datamodel.service.tasks import TaskType
-from docling_jobkit.datamodel.chunking import ChunkingExportOptions
-from docling_jobkit.datamodel.task import Task, TaskSource
 from docling_jobkit.orchestrators.base_orchestrator import (
     BaseOrchestrator,
     ProgressInvalid,
@@ -89,23 +66,44 @@ from docling_jobkit.orchestrators.base_orchestrator import (
 from docling_jobkit.orchestrators.rq.orchestrator import RQOrchestrator
 
 from docling_serve.auth import APIKeyAuth, AuthenticationResult
+from docling_serve.datamodel.convert import ConvertDocumentsRequestOptions
+from docling_serve.datamodel.requests import (
+    ConvertDocumentsRequest,
+    FileSourceRequest,
+    GenericChunkDocumentsRequest,
+    HttpSourceRequest,
+    S3SourceRequest,
+    TargetName,
+    TargetRequest,
+    make_request_model,
+)
+from docling_serve.datamodel.responses import (
+    ChunkDocumentResponse,
+    ClearResponse,
+    ConvertDocumentPublishedResponse,
+    ConvertDocumentResponse,
+    HealthCheckResponse,
+    MessageKind,
+    PresignedUrlConvertDocumentResponse,
+    ReadinessResponse,
+    TaskStatusResponse,
+    WebsocketMessage,
+)
 from docling_serve.helper_functions import DOCLING_VERSIONS, FormDepends
 from docling_serve.orchestrator_factory import get_async_orchestrator
 from docling_serve.otel_instrumentation import (
     get_metrics_endpoint_content,
     setup_otel_instrumentation,
 )
-from docling_serve.policy import (
-    build_service_policy,
-    normalize_convert_options,
-    normalize_convert_request,
-    validate_chunk_request,
-    validate_convert_options,
-    validate_convert_request,
-)
 from docling_serve.response_preparation import prepare_response
 from docling_serve.settings import AsyncEngine, docling_serve_settings
 from docling_serve.storage import get_scratch
+
+
+def _apply_default_image_export_mode(options: ConvertDocumentsRequestOptions):
+    if docling_serve_settings.resource_upload_enabled and options.image_export_mode == ImageRefMode.EMBEDDED:
+        options.image_export_mode = ImageRefMode.REFERENCED
+    return options
 from docling_serve.websocket_notifier import WebsocketNotifier
 
 # Pre-import OCR backends that use cysignals (signal handlers must be registered
@@ -219,7 +217,6 @@ def create_app():  # noqa: C901
         _log.info("Found static assets.")
 
     require_auth = APIKeyAuth(docling_serve_settings.api_key)
-    service_policy = build_service_policy(docling_serve_settings)
     app = FastAPI(
         title="Docling Serve",
         docs_url=None if offline_docs_assets else "/swagger",
@@ -393,10 +390,10 @@ def create_app():  # noqa: C901
         task_type: TaskType
         if isinstance(request, ConvertDocumentsRequest):
             task_type = TaskType.CONVERT
-            convert_options = request.options
+            convert_options = _apply_default_image_export_mode(request.options)
         elif isinstance(request, GenericChunkDocumentsRequest):
             task_type = TaskType.CHUNK
-            convert_options = request.convert_options
+            convert_options = _apply_default_image_export_mode(request.convert_options)
             chunking_options = request.chunking_options
             chunking_export_options.include_converted_doc = (
                 request.include_converted_doc
@@ -506,34 +503,6 @@ def create_app():  # noqa: C901
             elapsed_time = time.monotonic() - start_time
             if elapsed_time > docling_serve_settings.max_sync_wait:
                 return False
-
-    def _prepare_convert_request(
-        request: ConvertDocumentsRequest,
-    ) -> ConvertDocumentsRequest:
-        normalized_request = normalize_convert_request(request, service_policy)
-        validate_convert_request(normalized_request, service_policy)
-        return normalized_request
-
-    def _prepare_chunk_request(
-        request: GenericChunkDocumentsRequest,
-    ) -> GenericChunkDocumentsRequest:
-        normalized_request = request.model_copy(
-            update={
-                "convert_options": normalize_convert_options(
-                    request.convert_options, service_policy
-                )
-            },
-            deep=True,
-        )
-        validate_chunk_request(normalized_request, service_policy)
-        return normalized_request
-
-    def _prepare_convert_options(
-        options: ConvertDocumentsRequestOptions,
-    ) -> ConvertDocumentsRequestOptions:
-        normalized_options = normalize_convert_options(options, service_policy)
-        validate_convert_options(normalized_options, service_policy)
-        return normalized_options
 
     ##########################################
     # Downgrade openapi 3.1 to 3.0.x helpers #
@@ -678,7 +647,7 @@ def create_app():  # noqa: C901
     @app.post(
         "/v1/convert/source",
         tags=["convert"],
-        response_model=ConvertDocumentResponse | PresignedUrlConvertDocumentResponse,
+        response_model=ConvertDocumentResponse | ConvertDocumentPublishedResponse | PresignedUrlConvertDocumentResponse,
         responses={
             200: {
                 "content": {"application/zip": {}},
@@ -695,7 +664,6 @@ def create_app():  # noqa: C901
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
     ):
-        conversion_request = _prepare_convert_request(conversion_request)
         tenant_id = _get_tenant_id_from_header(x_tenant_id)
         _log.info(f"[TENANT_ID] process_url endpoint received tenant_id='{tenant_id}'")
         task = await _enque_source(
@@ -730,7 +698,7 @@ def create_app():  # noqa: C901
     @app.post(
         "/v1/convert/file",
         tags=["convert"],
-        response_model=ConvertDocumentResponse | PresignedUrlConvertDocumentResponse,
+        response_model=ConvertDocumentResponse | ConvertDocumentPublishedResponse | PresignedUrlConvertDocumentResponse,
         responses={
             200: {
                 "content": {"application/zip": {}},
@@ -750,7 +718,6 @@ def create_app():  # noqa: C901
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
     ):
-        options = _prepare_convert_options(options)
         tenant_id = _get_tenant_id_from_header(x_tenant_id)
         _log.info(f"[TENANT_ID] process_file endpoint received tenant_id='{tenant_id}'")
         target = InBodyTarget() if target_type == TargetName.INBODY else ZipTarget()
@@ -758,7 +725,7 @@ def create_app():  # noqa: C901
             task_type=TaskType.CONVERT,
             orchestrator=orchestrator,
             files=files,
-            convert_options=options,
+            convert_options=_apply_default_image_export_mode(options),
             chunking_options=None,
             chunking_export_options=None,
             target=target,
@@ -804,7 +771,6 @@ def create_app():  # noqa: C901
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
     ):
-        conversion_request = _prepare_convert_request(conversion_request)
         tenant_id = _get_tenant_id_from_header(x_tenant_id)
         _log.info(
             f"[TENANT_ID] process_url_async endpoint received tenant_id='{tenant_id}'"
@@ -843,7 +809,6 @@ def create_app():  # noqa: C901
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
     ):
-        options = _prepare_convert_options(options)
         tenant_id = _get_tenant_id_from_header(x_tenant_id)
         _log.info(
             f"[TENANT_ID] process_file_async endpoint received tenant_id='{tenant_id}'"
@@ -853,7 +818,7 @@ def create_app():  # noqa: C901
             task_type=TaskType.CONVERT,
             orchestrator=orchestrator,
             files=files,
-            convert_options=options,
+            convert_options=_apply_default_image_export_mode(options),
             chunking_options=None,
             chunking_export_options=None,
             target=target,
@@ -895,7 +860,6 @@ def create_app():  # noqa: C901
                 Header(alias=docling_serve_settings.eng_ray_tenant_id_header),
             ] = None,
         ):
-            request = _prepare_chunk_request(request)
             tenant_id = _get_tenant_id_from_header(x_tenant_id)
             _log.info(
                 f"[TENANT_ID] chunk_source_async ({path_name}) endpoint received tenant_id='{tenant_id}'"
@@ -959,7 +923,6 @@ def create_app():  # noqa: C901
                 Header(alias=docling_serve_settings.eng_ray_tenant_id_header),
             ] = None,
         ):
-            convert_options = _prepare_convert_options(convert_options)
             tenant_id = _get_tenant_id_from_header(x_tenant_id)
             _log.info(
                 f"[TENANT_ID] chunk_file_async ({path_name}) endpoint received tenant_id='{tenant_id}'"
@@ -1012,7 +975,6 @@ def create_app():  # noqa: C901
                 Header(alias=docling_serve_settings.eng_ray_tenant_id_header),
             ] = None,
         ):
-            request = _prepare_chunk_request(request)
             tenant_id = _get_tenant_id_from_header(x_tenant_id)
             _log.info(
                 f"[TENANT_ID] chunk_source ({path_name}) endpoint received tenant_id='{tenant_id}'"
@@ -1094,7 +1056,6 @@ def create_app():  # noqa: C901
                 Header(alias=docling_serve_settings.eng_ray_tenant_id_header),
             ] = None,
         ):
-            convert_options = _prepare_convert_options(convert_options)
             tenant_id = _get_tenant_id_from_header(x_tenant_id)
             _log.info(
                 f"[TENANT_ID] chunk_file ({path_name}) endpoint received tenant_id='{tenant_id}'"

--- a/docling_serve/datamodel/responses.py
+++ b/docling_serve/datamodel/responses.py
@@ -1,3 +1,89 @@
-"""Deprecated compatibility shim. Use `docling.datamodel.service.responses` instead."""
+import enum
+from typing import Optional
 
-from docling.datamodel.service.responses import *  # noqa: F403
+from pydantic import BaseModel
+
+from docling.datamodel.document import ConversionStatus, ErrorItem
+from docling.utils.profiling import ProfilingItem
+from docling_jobkit.datamodel.result import (
+    ChunkedDocumentResultItem,
+    ExportDocumentResponse,
+    ExportResult,
+)
+from docling_jobkit.datamodel.task_meta import TaskProcessingMeta, TaskType
+
+
+# Status
+class HealthCheckResponse(BaseModel):
+    status: str = "ok"
+
+
+class ReadinessResponse(BaseModel):
+    status: str = "ok"
+
+
+class ClearResponse(BaseModel):
+    status: str = "ok"
+
+
+class ConvertDocumentResponse(BaseModel):
+    document: ExportDocumentResponse
+    status: ConversionStatus
+    errors: list[ErrorItem] = []
+    processing_time: float
+    timings: dict[str, ProfilingItem] = {}
+
+
+class PublishedArtifactResponse(BaseModel):
+    filename: str
+    local_path: str
+    file_id: Optional[str] = None
+    download_url: Optional[str] = None
+    content_type: Optional[str] = None
+    size_bytes: Optional[int] = None
+
+
+class ConvertDocumentPublishedResponse(BaseModel):
+    artifact: PublishedArtifactResponse
+    status: ConversionStatus
+    errors: list[ErrorItem] = []
+    processing_time: float
+    timings: dict[str, ProfilingItem] = {}
+
+
+class PresignedUrlConvertDocumentResponse(BaseModel):
+    processing_time: float
+    num_converted: int
+    num_succeeded: int
+    num_failed: int
+
+
+class ConvertDocumentErrorResponse(BaseModel):
+    status: ConversionStatus
+
+
+class ChunkDocumentResponse(BaseModel):
+    chunks: list[ChunkedDocumentResultItem]
+    documents: list[ExportResult]
+    processing_time: float
+
+
+class TaskStatusResponse(BaseModel):
+    task_id: str
+    task_type: TaskType
+    task_status: str
+    task_position: Optional[int] = None
+    task_meta: Optional[TaskProcessingMeta] = None
+    error_message: Optional[str] = None
+
+
+class MessageKind(str, enum.Enum):
+    CONNECTION = "connection"
+    UPDATE = "update"
+    ERROR = "error"
+
+
+class WebsocketMessage(BaseModel):
+    message: MessageKind
+    task: Optional[TaskStatusResponse] = None
+    error: Optional[str] = None

--- a/docling_serve/resource_rewriter.py
+++ b/docling_serve/resource_rewriter.py
@@ -1,0 +1,220 @@
+import logging
+import mimetypes
+import posixpath
+import re
+from pathlib import Path
+from urllib.parse import unquote, unquote_plus
+
+import requests
+
+from docling_serve.settings import docling_serve_settings
+from docling_serve.storage import get_scratch
+
+_log = logging.getLogger(__name__)
+
+
+class ResourceUploadError(RuntimeError):
+    pass
+
+
+class ResourceUploader:
+    def __init__(self):
+        self.upload_url = docling_serve_settings.resource_upload_url
+        self.download_url_template = docling_serve_settings.resource_download_url_template
+        self.file_field_name = docling_serve_settings.resource_upload_file_field_name
+        self.timeout = docling_serve_settings.resource_upload_timeout_seconds
+        self.extra_form_data = docling_serve_settings.resource_upload_form_data or {}
+        self._cache: dict[str, str] = {}
+
+    def enabled(self) -> bool:
+        return (
+            docling_serve_settings.resource_upload_enabled
+            and bool(self.upload_url)
+            and bool(self.download_url_template)
+        )
+
+    def _upload(self, file_path: Path) -> str:
+        content_type, _ = mimetypes.guess_type(file_path.name)
+        content_type = content_type or "application/octet-stream"
+        with file_path.open("rb") as f:
+            files = {self.file_field_name: (file_path.name, f, content_type)}
+            resp = requests.post(
+                self.upload_url,
+                data=self.extra_form_data,
+                files=files,
+                timeout=self.timeout,
+            )
+        resp.raise_for_status()
+        payload = resp.json()
+        if not payload.get("success"):
+            raise ResourceUploadError(f"upload failed: {payload}")
+        data = payload.get("data") or []
+        if not data:
+            raise ResourceUploadError(f"missing file id: {payload}")
+        file_id = data[0]
+        return self.download_url_template.format(file_id=file_id)
+
+    def _search_roots(self, base_dir: Path) -> list[Path]:
+        roots = []
+        for p in [base_dir, Path(docling_serve_settings.resource_local_base_dir or "."), get_scratch()]:
+            try:
+                rp = p.resolve()
+            except Exception:
+                rp = p
+            if rp not in roots and rp.exists():
+                roots.append(rp)
+        return roots
+
+    def _resolve_path(self, ref: str, base_dir: Path) -> Path | None:
+        ref = (ref or "").strip().strip(chr(34) + chr(39))
+        ref_name = Path(posixpath.basename(ref)).name
+        ref_path = Path(ref)
+
+        if ref_path.is_absolute() and ref_path.exists():
+            return ref_path.resolve()
+
+        roots = self._search_roots(base_dir)
+        for root in roots:
+            if not ref_path.is_absolute():
+                candidate = (root / ref_path).resolve()
+                if candidate.exists():
+                    return candidate
+            if ref_name:
+                direct = (root / ref_name).resolve()
+                if direct.exists():
+                    return direct
+                matches = list(root.glob(f"*_artifacts/{ref_name}"))
+                if matches:
+                    return matches[0].resolve()
+                matches = list(root.rglob(ref_name))
+                if matches:
+                    return matches[0].resolve()
+        return None
+
+    def upload_once(self, ref: str, base_dir: Path) -> str:
+        if ref in self._cache:
+            return self._cache[ref]
+        if ref.startswith("http://") or ref.startswith("https://"):
+            return ref
+        if ref.startswith("data:"):
+            return ref
+        path = self._resolve_path(ref, base_dir)
+        if path is None:
+            _log.warning("resource file not found, skip upload: %s (base_dir=%s)", ref, base_dir)
+            return ref
+        remote_url = self._upload(path)
+        self._cache[ref] = remote_url
+        return remote_url
+
+
+MD_IMAGE_PATTERN = re.compile(r'!\[([^\]]*)\]\(([^)\s]+(?:\s+"[^"]*")?)\)')
+HTML_IMAGE_PATTERN = re.compile(r"(<img[^>]*src=[\"'])([^\"']+)([\"'][^>]*>)", re.IGNORECASE)
+BROKEN_MD_PREFIX_PATTERN = re.compile(r'\uFFFD?!\[', re.MULTILINE)
+
+
+def rewrite_markdown(content: str, uploader: ResourceUploader, base_dir: Path) -> str:
+    content = BROKEN_MD_PREFIX_PATTERN.sub('![', content)
+
+    def repl(match):
+        alt = match.group(1)
+        ref = match.group(2).strip()
+        if ref.startswith("<") and ref.endswith(">"):
+            ref = ref[1:-1].strip()
+        if " " in ref and not ref.startswith(("http://", "https://", "/")):
+            ref = ref.split(" ", 1)[0].strip()
+        remote = uploader.upload_once(ref, base_dir)
+        return f"![{alt}]({remote})"
+
+    return MD_IMAGE_PATTERN.sub(repl, content)
+
+
+def rewrite_html(content: str, uploader: ResourceUploader, base_dir: Path) -> str:
+    def repl(match):
+        prefix = match.group(1)
+        ref = match.group(2).strip()
+        suffix = match.group(3)
+        remote = uploader.upload_once(ref, base_dir)
+        return f"{prefix}{remote}{suffix}"
+
+    return HTML_IMAGE_PATTERN.sub(repl, content)
+
+
+def rewrite_json_obj(obj, uploader: ResourceUploader, base_dir: Path):
+    if isinstance(obj, dict):
+        return {k: rewrite_json_obj(v, uploader, base_dir) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [rewrite_json_obj(v, uploader, base_dir) for v in obj]
+    if isinstance(obj, str):
+        if obj.startswith("data:") and docling_serve_settings.resource_strip_base64_data_urls:
+            return ""
+        lower = obj.lower()
+        if lower.endswith((".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg")):
+            try:
+                return uploader.upload_once(obj, base_dir)
+            except Exception:
+                _log.exception("failed to upload json resource: %s", obj)
+                return obj
+        return obj
+    return obj
+
+
+def rewrite_export_document(document):
+    uploader = ResourceUploader()
+    if not uploader.enabled():
+        return document
+    root_dir = Path(docling_serve_settings.resource_local_base_dir or ".")
+    real_output_dir = Path(document.output_dir) if getattr(document, "output_dir", None) else None
+    raw_filename = getattr(document, "filename", "document")
+    decoded_candidates = []
+    for candidate in [raw_filename, unquote(raw_filename), unquote_plus(raw_filename)]:
+        if candidate and candidate not in decoded_candidates:
+            decoded_candidates.append(candidate)
+    stems = []
+    for candidate in decoded_candidates:
+        stem = Path(candidate).stem
+        if stem and stem not in stems:
+            stems.append(stem)
+    preferred_dirs = [
+        real_output_dir / "artifacts" if real_output_dir else None,
+        real_output_dir,
+    ]
+    for stem in stems:
+        preferred_dirs.extend([
+            root_dir / f"{stem}_artifacts",
+            get_scratch() / f"{stem}_artifacts",
+        ])
+    preferred_dirs.extend([root_dir, get_scratch()])
+    base_dir = next((p for p in preferred_dirs if p is not None and p.exists()), root_dir)
+    _log.warning("DIAG rewriter filename=%s decoded=%s output_dir=%s base_dir=%s", raw_filename, decoded_candidates, getattr(document, "output_dir", None), base_dir)
+    if getattr(document, "md_content", None):
+        document.md_content = rewrite_markdown(document.md_content, uploader, base_dir)
+    if getattr(document, "html_content", None):
+        document.html_content = rewrite_html(document.html_content, uploader, base_dir)
+    if getattr(document, "json_content", None) is not None:
+        data = document.json_content.model_dump(mode="json")
+        data = rewrite_json_obj(data, uploader, base_dir)
+        document.json_content = type(document.json_content).model_validate(data)
+    return document
+
+
+def upload_file_and_collect(file_path: Path):
+    uploader = ResourceUploader()
+    local_path = file_path.resolve()
+    result = {
+        "filename": local_path.name,
+        "local_path": str(local_path),
+        "file_id": None,
+        "download_url": None,
+        "content_type": mimetypes.guess_type(local_path.name)[0] or "application/octet-stream",
+        "size_bytes": local_path.stat().st_size if local_path.exists() else None,
+    }
+    if not local_path.exists():
+        return result
+    if not uploader.enabled():
+        return result
+    remote_url = uploader._upload(local_path)
+    result["download_url"] = remote_url
+    marker = '/downloadfile/'
+    if marker in remote_url:
+        result["file_id"] = remote_url.split(marker, 1)[1].split('?', 1)[0]
+    return result

--- a/docling_serve/response_preparation.py
+++ b/docling_serve/response_preparation.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from pathlib import Path
 from urllib.parse import unquote, unquote_plus
 
@@ -28,6 +29,69 @@ from docling_serve.settings import docling_serve_settings
 
 _log = logging.getLogger(__name__)
 
+_CJK_CHAR_RE = r"\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff"
+_CJK_PUNCT_RE = r"，。！？；：、】【（）《》“”‘’、"
+_CJK_CHAR_CLASS = f"[{_CJK_CHAR_RE}]"
+_CJK_OR_PUNCT_CLASS = f"[{_CJK_CHAR_RE}{_CJK_PUNCT_RE}]"
+
+
+def _merge_broken_cjk_lines(text: str) -> str:
+    lines = text.splitlines()
+    if len(lines) <= 1:
+        return text
+
+    merged: list[str] = []
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not merged:
+            merged.append(line)
+            continue
+        if not line:
+            merged.append(line)
+            continue
+
+        prev = merged[-1]
+        if not prev:
+            merged.append(line)
+            continue
+
+        is_new_block = bool(
+            re.match(r"^(#{1,6}\s|[-*+]\s|\d+[.)、]\s*|[（(]?[一二三四五六七八九十]+[）)]\s*)", line)
+        )
+        prev_ends_sentence = bool(re.search(r"[。！？!?；;：:]$", prev))
+        line_is_short_cjk = bool(re.fullmatch(rf"{_CJK_OR_PUNCT_CLASS}{{1,6}}", line))
+        prev_ends_with_cjk = bool(re.search(rf"{_CJK_OR_PUNCT_CLASS}$", prev))
+        line_starts_with_cjk = bool(re.match(rf"^{_CJK_OR_PUNCT_CLASS}", line))
+
+        if not is_new_block and not prev_ends_sentence and (
+            line_is_short_cjk or (prev_ends_with_cjk and line_starts_with_cjk)
+        ):
+            merged[-1] = prev + line
+        else:
+            merged.append(line)
+
+    return "\n".join(merged)
+
+
+def _normalize_cjk_spacing(text: str) -> str:
+    text = _merge_broken_cjk_lines(text)
+    text = re.sub(rf"(?<={_CJK_CHAR_CLASS})[ \t]+(?={_CJK_CHAR_CLASS})", "", text)
+    text = re.sub(rf"(?<={_CJK_OR_PUNCT_CLASS})[ \t]+(?=[{_CJK_PUNCT_RE}])", "", text)
+    text = re.sub(rf"(?<=[{_CJK_PUNCT_RE}])[ \t]+(?={_CJK_OR_PUNCT_CLASS})", "", text)
+    text = re.sub(rf"([（《“‘【])\s+(?={_CJK_OR_PUNCT_CLASS})", r"\1", text)
+    text = re.sub(rf"(?<={_CJK_OR_PUNCT_CLASS})\s+([）》”’】])", r"\1", text)
+    return text
+
+
+def _normalize_export_json_payload(payload: object):
+    if isinstance(payload, dict):
+        return {k: _normalize_export_json_payload(v) for k, v in payload.items()}
+    if isinstance(payload, list):
+        return [_normalize_export_json_payload(v) for v in payload]
+    if isinstance(payload, str):
+        return _normalize_cjk_spacing(payload)
+    return payload
+
 
 def _publish_text_file(filename: str, suffix: str, content: str):
     base_dir = Path(docling_serve_settings.resource_local_base_dir or ".")
@@ -42,7 +106,8 @@ def _publish_text_file(filename: str, suffix: str, content: str):
         except Exception:
             pass
     out_path = base_dir / f"{Path(decoded_filename).stem}{suffix}"
-    out_path.write_text(content, encoding="utf-8")
+    normalized_content = _normalize_cjk_spacing(content)
+    out_path.write_text(normalized_content, encoding="utf-8")
     return upload_file_and_collect(out_path)
 
 
@@ -79,6 +144,7 @@ async def prepare_response(
             filename = Path(decoded_filename).stem + ".json"
             json_path = base_dir / filename
             json_payload = rewritten_document.json_content.model_dump(mode="json")
+            json_payload = _normalize_export_json_payload(json_payload)
 
             # 修正 JSON 内部的 name 和 origin.filename
             if "name" in json_payload and json_payload["name"]:

--- a/docling_serve/response_preparation.py
+++ b/docling_serve/response_preparation.py
@@ -1,12 +1,10 @@
+import json
 import logging
+from pathlib import Path
+from urllib.parse import unquote, unquote_plus
 
 from fastapi import BackgroundTasks, Response
 
-from docling.datamodel.service.responses import (
-    ChunkDocumentResponse,
-    ConvertDocumentResponse,
-    PresignedUrlConvertDocumentResponse,
-)
 from docling_jobkit.datamodel.result import (
     ChunkedDocumentResult,
     DoclingTaskResult,
@@ -18,9 +16,34 @@ from docling_jobkit.orchestrators.base_orchestrator import (
     BaseOrchestrator,
 )
 
+from docling_serve.datamodel.responses import (
+    ChunkDocumentResponse,
+    ConvertDocumentPublishedResponse,
+    ConvertDocumentResponse,
+    PresignedUrlConvertDocumentResponse,
+    PublishedArtifactResponse,
+)
+from docling_serve.resource_rewriter import rewrite_export_document, upload_file_and_collect
 from docling_serve.settings import docling_serve_settings
 
 _log = logging.getLogger(__name__)
+
+
+def _publish_text_file(filename: str, suffix: str, content: str):
+    base_dir = Path(docling_serve_settings.resource_local_base_dir or ".")
+    base_dir.mkdir(parents=True, exist_ok=True)
+    decoded_filename = filename
+    for decoder in [unquote, unquote_plus]:
+        try:
+            candidate = decoder(filename)
+            if '%' not in candidate and candidate != filename:
+                decoded_filename = candidate
+                break
+        except Exception:
+            pass
+    out_path = base_dir / f"{Path(decoded_filename).stem}{suffix}"
+    out_path.write_text(content, encoding="utf-8")
+    return upload_file_and_collect(out_path)
 
 
 async def prepare_response(
@@ -32,17 +55,99 @@ async def prepare_response(
     response: (
         Response
         | ConvertDocumentResponse
+        | ConvertDocumentPublishedResponse
         | PresignedUrlConvertDocumentResponse
         | ChunkDocumentResponse
     )
     if isinstance(task_result.result, ExportResult):
-        response = ConvertDocumentResponse(
-            document=task_result.result.content,
-            status=task_result.result.status,
-            processing_time=task_result.processing_time,
-            timings=task_result.result.timings,
-            errors=task_result.result.errors,
-        )
+        _log.warning("DIAG prep before rewrite filename=%s output_dir=%s", getattr(task_result.result.content, "filename", None), getattr(task_result.result.content, "output_dir", None))
+        rewritten_document = rewrite_export_document(task_result.result.content)
+        _log.warning("DIAG prep after rewrite filename=%s output_dir=%s", getattr(rewritten_document, "filename", None), getattr(rewritten_document, "output_dir", None))
+        if getattr(rewritten_document, "json_content", None) is not None:
+            base_dir = Path(docling_serve_settings.resource_local_base_dir or ".")
+            base_dir.mkdir(parents=True, exist_ok=True)
+            raw_filename = rewritten_document.filename
+            decoded_filename = raw_filename
+            for decoder in [unquote, unquote_plus]:
+                try:
+                    candidate = decoder(raw_filename)
+                    if '%' not in candidate and candidate != raw_filename:
+                        decoded_filename = candidate
+                        break
+                except Exception:
+                    pass
+            filename = Path(decoded_filename).stem + ".json"
+            json_path = base_dir / filename
+            json_payload = rewritten_document.json_content.model_dump(mode="json")
+
+            # 修正 JSON 内部的 name 和 origin.filename
+            if "name" in json_payload and json_payload["name"]:
+                json_payload["name"] = decoded_filename
+            if "origin" in json_payload and isinstance(json_payload["origin"], dict):
+                if "filename" in json_payload["origin"]:
+                    json_payload["origin"]["filename"] = decoded_filename
+
+            json_path.write_text(
+                json.dumps(json_payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            upload_meta = upload_file_and_collect(json_path)
+            response = ConvertDocumentPublishedResponse(
+                artifact=PublishedArtifactResponse(**upload_meta),
+                status=task_result.result.status,
+                processing_time=task_result.processing_time,
+                timings=task_result.result.timings,
+                errors=task_result.result.errors,
+            )
+        elif getattr(rewritten_document, "md_content", None):
+            upload_meta = _publish_text_file(
+                rewritten_document.filename,
+                ".md",
+                rewritten_document.md_content,
+            )
+            response = ConvertDocumentPublishedResponse(
+                artifact=PublishedArtifactResponse(**upload_meta),
+                status=task_result.result.status,
+                processing_time=task_result.processing_time,
+                timings=task_result.result.timings,
+                errors=task_result.result.errors,
+            )
+        elif getattr(rewritten_document, "html_content", None):
+            upload_meta = _publish_text_file(
+                rewritten_document.filename,
+                ".html",
+                rewritten_document.html_content,
+            )
+            response = ConvertDocumentPublishedResponse(
+                artifact=PublishedArtifactResponse(**upload_meta),
+                status=task_result.result.status,
+                processing_time=task_result.processing_time,
+                timings=task_result.result.timings,
+                errors=task_result.result.errors,
+            )
+        elif getattr(rewritten_document, "text_content", None):
+            upload_meta = _publish_text_file(
+                rewritten_document.filename,
+                ".txt",
+                rewritten_document.text_content,
+            )
+            response = ConvertDocumentPublishedResponse(
+                artifact=PublishedArtifactResponse(**upload_meta),
+                status=task_result.result.status,
+                processing_time=task_result.processing_time,
+                timings=task_result.result.timings,
+                errors=task_result.result.errors,
+            )
+        else:
+            response = ConvertDocumentResponse(
+                document=type(task_result.result.content).model_validate(
+                    rewritten_document.model_dump(mode="json")
+                ),
+                status=task_result.result.status,
+                processing_time=task_result.processing_time,
+                timings=task_result.result.timings,
+                errors=task_result.result.errors,
+            )
     elif isinstance(task_result.result, ZipArchiveResult):
         response = Response(
             content=task_result.result.content,

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -259,6 +259,16 @@ class DoclingServeSettings(BaseSettings):
     # Metrics
     metrics_port: Optional[int] = None
 
+    # Resource upload post-processing
+    resource_upload_enabled: bool = False
+    resource_upload_url: Optional[str] = None
+    resource_download_url_template: Optional[str] = None
+    resource_upload_file_field_name: str = "aaa"
+    resource_upload_form_data: dict[str, str] = Field(default_factory=dict)
+    resource_upload_timeout_seconds: int = 60
+    resource_local_base_dir: Optional[Path] = None
+    resource_strip_base64_data_urls: bool = True
+
     # === DoclingConverterManagerConfig Parameters ===
     # TODO: Don't overwrite the default of docling-jobkit. This requires first some restructure in jobkit.
 


### PR DESCRIPTION
## Summary\n- normalize Chinese spacing in response payload text fields after document rewrite\n- keep response payloads aligned with the export-layer Chinese text cleanup\n- preserve English and numeric spacing while fixing obvious broken Chinese fragments\n\n## Validation\n- reproduced the issue with Chinese PDF exports in the official image\n- verified response payloads now apply the same Chinese text normalization path used by the local hotfix\n\n## Notes\n- the main content-generation fix lives in docling-jobkit; this PR is the response-layer companion for consistency\n