### PR TITLE
feat: Add `/v1/capacity` endpoint, 429 handler, and optional admission gate

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -10,7 +10,7 @@ import time
 from collections import Counter
 from contextlib import asynccontextmanager
 from io import BytesIO
-from typing import Annotated
+from typing import Annotated, Optional
 
 import psutil
 from fastapi import (
@@ -84,11 +84,14 @@ from docling_jobkit.orchestrators.base_orchestrator import (
     BaseOrchestrator,
     ProgressInvalid,
     RedisBackpressureError,
+    SystemCapacity,
     TaskNotFoundError,
 )
+from docling_jobkit.orchestrators.ray.orchestrator import QueueLimitExceededError
 from docling_jobkit.orchestrators.rq.orchestrator import RQOrchestrator
 
 from docling_serve.auth import APIKeyAuth, AuthenticationResult
+from docling_serve.capacity import get_cached_capacity
 from docling_serve.helper_functions import DOCLING_VERSIONS, FormDepends
 from docling_serve.orchestrator_factory import get_async_orchestrator
 from docling_serve.otel_instrumentation import (
@@ -237,6 +240,21 @@ def create_app():  # noqa: C901
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             content={"detail": "Server is busy, please try again shortly."},
             headers={"Retry-After": "1"},
+        )
+
+    @app.exception_handler(QueueLimitExceededError)
+    async def queue_limit_exceeded_handler(
+        request: Request, exc: QueueLimitExceededError
+    ) -> JSONResponse:
+        del request
+        capacity = await get_cached_capacity(get_async_orchestrator())
+        return JSONResponse(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            content={
+                "detail": str(exc),
+                "capacity": capacity.model_dump() if capacity else None,
+            },
+            headers={"Retry-After": "5"},
         )
 
     # Setup OpenTelemetry instrumentation
@@ -397,6 +415,13 @@ def create_app():  # noqa: C901
         else:
             _log.warning("[TENANT_ID] No tenant_id provided, will use default")
 
+        if docling_serve_settings.admission_max_queue_size is not None:
+            size = await orchestrator.queue_size()
+            if size >= docling_serve_settings.admission_max_queue_size:
+                raise QueueLimitExceededError(
+                    f"Queue full ({size}/{docling_serve_settings.admission_max_queue_size})"
+                )
+
         task = await orchestrator.enqueue(
             task_type=task_type,
             sources=sources,
@@ -451,6 +476,13 @@ def create_app():  # noqa: C901
         metadata = {}
         if tenant_id:
             metadata["tenant_id"] = tenant_id
+
+        if docling_serve_settings.admission_max_queue_size is not None:
+            size = await orchestrator.queue_size()
+            if size >= docling_serve_settings.admission_max_queue_size:
+                raise QueueLimitExceededError(
+                    f"Queue full ({size}/{docling_serve_settings.admission_max_queue_size})"
+                )
 
         task = await orchestrator.enqueue(
             task_type=task_type,
@@ -635,6 +667,14 @@ def create_app():  # noqa: C901
     @app.get("/api", include_in_schema=False)
     def api_check() -> HealthCheckResponse:
         return HealthCheckResponse()
+
+    # Capacity endpoint
+    @app.get("/v1/capacity", tags=["system"])
+    async def get_capacity(
+        orchestrator: Annotated[BaseOrchestrator, Depends(get_async_orchestrator)],
+    ) -> Optional[SystemCapacity]:
+        """Get system-level capacity snapshot for back pressure signalling."""
+        return await get_cached_capacity(orchestrator)
 
     # Docling versions
     @app.get("/version", tags=["health"])

--- a/docling_serve/capacity.py
+++ b/docling_serve/capacity.py
@@ -1,0 +1,24 @@
+"""Cached capacity snapshot for the /v1/capacity endpoint."""
+
+import time
+from typing import Optional
+
+from docling_jobkit.orchestrators.base_orchestrator import (
+    BaseOrchestrator,
+    SystemCapacity,
+)
+
+_cached: Optional[SystemCapacity] = None
+_cached_at: float = 0.0
+_CACHE_TTL: float = 2.0
+
+
+async def get_cached_capacity(
+    orchestrator: BaseOrchestrator,
+) -> Optional[SystemCapacity]:
+    global _cached, _cached_at
+    now = time.monotonic()
+    if _cached is None or (now - _cached_at) > _CACHE_TTL:
+        _cached = await orchestrator.get_capacity()
+        _cached_at = now
+    return _cached

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -131,6 +131,9 @@ class DoclingServeSettings(BaseSettings):
     sync_poll_interval: int = 2  # seconds
     max_sync_wait: int = 120  # 2 minutes
 
+    capacity_cache_ttl: float = 2.0  # seconds
+    admission_max_queue_size: Optional[int] = None
+
     cors_origins: list[str] = ["*"]
     cors_methods: list[str] = ["*"]
     cors_headers: list[str] = ["*"]

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -1,0 +1,104 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from asgi_lifespan import LifespanManager
+from httpx import ASGITransport, AsyncClient
+
+from docling_serve.app import create_app
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    return asyncio.get_event_loop()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def app():
+    app = create_app()
+    async with LifespanManager(app) as manager:
+        yield manager.app
+
+
+@pytest_asyncio.fixture(scope="session")
+async def client(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://app.io"
+    ) as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_capacity_endpoint_returns_data(client: AsyncClient):
+    response = await client.get("/v1/capacity")
+    assert response.status_code == 200
+    data = response.json()
+    assert "queue_depth" in data
+    assert "active_jobs" in data
+    assert "active_workers" in data
+
+
+@pytest.mark.asyncio
+async def test_capacity_endpoint_fields_are_ints(client: AsyncClient):
+    response = await client.get("/v1/capacity")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data["queue_depth"], int)
+    assert isinstance(data["active_jobs"], int)
+    assert isinstance(data["active_workers"], int)
+
+
+@pytest.mark.asyncio
+async def test_queue_limit_exceeded_returns_429(client: AsyncClient):
+    from docling_jobkit.orchestrators.ray.orchestrator import (
+        QueueLimitExceededError,
+    )
+
+    async def _raise(*args, **kwargs):
+        raise QueueLimitExceededError("Queue full (10/10)")
+
+    with patch("docling_serve.app.get_async_orchestrator") as mock_get_orch:
+        mock_orch = AsyncMock()
+        mock_orch.enqueue = _raise
+        mock_orch.get_capacity = AsyncMock(return_value=None)
+        mock_get_orch.return_value = mock_orch
+
+        response = await client.post(
+            "/v1/convert/source/async",
+            json={
+                "sources": [{"url": "https://example.com/test.pdf"}],
+                "options": {},
+            },
+        )
+
+    assert response.status_code == 429
+    data = response.json()
+    assert "Queue full" in data["detail"]
+    assert "Retry-After" in response.headers
+
+
+@pytest.mark.asyncio
+async def test_redis_backpressure_returns_503(client: AsyncClient):
+    from docling_jobkit.orchestrators.base_orchestrator import (
+        RedisBackpressureError,
+    )
+
+    async def _raise(*args, **kwargs):
+        raise RedisBackpressureError("saturated")
+
+    with patch("docling_serve.app.get_async_orchestrator") as mock_get_orch:
+        mock_orch = AsyncMock()
+        mock_orch.enqueue = _raise
+        mock_get_orch.return_value = mock_orch
+
+        response = await client.post(
+            "/v1/convert/source/async",
+            json={
+                "sources": [{"url": "https://example.com/test.pdf"}],
+                "options": {},
+            },
+        )
+
+    assert response.status_code == 503
+    assert "Retry-After" in response.headers


### PR DESCRIPTION
Depends on docling-project/docling-jobkit#126 (`SystemCapacity` + `get_capacity()`).

See #581  for full problem descriptio

## Summary

- **`GET /v1/capacity`** - returns system-level capacity snapshot (queue depth, active jobs, worker count); cached with configurable TTL (default 2s) to avoid per-request Redis scans
- **`QueueLimitExceededError` → 429** - fixes unhandled 500 when Ray queue limit rejection is enabled; returns capacity snapshot in response body
- **Optional admission gate** - new `admission_max_queue_size` setting; when set, rejects submissions with 429 before `enqueue()` if queue is full

**Issue resolved by this Pull Request:**
Resolves #581 
