### PR TITLE
Dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,15 @@ UVICORN_RELOAD=True
 # DOCLING_SERVE_ALLOWED_LAYOUT_KINDS='["docling_layout_default", "layout_object_detection"]'
 # DOCLING_SERVE_ALLOWED_LAYOUT_KINDS=docling_layout_default,layout_object_detection
 
+# ============================================================================
+# OCR Control
+# ============================================================================
+# Preferred OCR defaults for requests that do not specify OCR explicitly:
+# DOCLING_SERVE_DEFAULT_OCR_KIND=auto
+# DOCLING_SERVE_DEFAULT_OCR_PRESET=auto
+# Optional compatibility alias (deprecated):
+# DOCLING_SERVE_OCR_ENGINE=auto
+
 # Ray Engine Configuration
 # ============================================================================
 # The Ray engine uses Ray Serve for autoscaling document processing with

--- a/Containerfile
+++ b/Containerfile
@@ -3,6 +3,7 @@ ARG BASE_IMAGE=quay.io/sclorg/python-312-c9s:c9s
 ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.8.19
 
 ARG UV_SYNC_EXTRA_ARGS=""
+ARG DOCLING_EXTRA_PLUGINS=""
 
 ARG MIMALLOC_VERSION=v3.2.8
 
@@ -74,6 +75,7 @@ ENV \
     DOCLING_SERVE_ARTIFACTS_PATH=/opt/app-root/src/.cache/docling/models
 
 ARG UV_SYNC_EXTRA_ARGS
+ARG DOCLING_EXTRA_PLUGINS
 
 RUN --mount=from=uv_stage,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/opt/app-root/src/.cache/uv,uid=1001 \
@@ -100,6 +102,15 @@ RUN --mount=from=uv_stage,source=/uv,target=/bin/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     umask 002 && uv sync --frozen --no-dev --all-extras ${UV_SYNC_EXTRA_ARGS}
+
+RUN --mount=from=uv_stage,source=/uv,target=/bin/uv \
+    --mount=type=cache,target=/opt/app-root/src/.cache/uv,uid=1001 \
+    if [ -n "${DOCLING_EXTRA_PLUGINS}" ]; then \
+      echo "Installing external docling plugins: ${DOCLING_EXTRA_PLUGINS}" && \
+      uv pip install --python /opt/app-root/bin/python ${DOCLING_EXTRA_PLUGINS}; \
+    else \
+      echo "No external docling plugins configured."; \
+    fi
 
 ENV LD_PRELOAD=/usr/local/lib/libmimalloc.so
 EXPOSE 5001

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,17 @@ endif
 
 # Container runtime - can be overridden: make CONTAINER_RUNTIME=podman cmd
 CONTAINER_RUNTIME ?= docker
+SURYA_EXTRA_PLUGINS ?= docling-surya transformers==4.57.1
+IMAGE_ORG_GHCR ?= ghcr.io/docling-project
+IMAGE_ORG_QUAY ?= quay.io/docling-project
 
 TAG=$(shell git rev-parse HEAD)
 BRANCH_TAG=$(shell git rev-parse --abbrev-ref HEAD)
+
+define tag_branch_aliases
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag $(IMAGE_ORG_GHCR)/$(1):$(TAG) $(IMAGE_ORG_GHCR)/$(1):$(BRANCH_TAG)
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag $(IMAGE_ORG_GHCR)/$(1):$(TAG) $(IMAGE_ORG_QUAY)/$(1):$(BRANCH_TAG)
+endef
 
 action-lint-file:
 	$(CMD_PREFIX) touch .action-lint
@@ -31,51 +39,62 @@ md-lint-file:
 .PHONY: docling-serve-image
 docling-serve-image: Containerfile ## Build docling-serve container image
 	$(ECHO_PREFIX) printf "  %-12s Containerfile\n" "[docling-serve]"
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load -f Containerfile -t ghcr.io/docling-project/docling-serve:$(TAG) .
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve:$(TAG) ghcr.io/docling-project/docling-serve:$(BRANCH_TAG)
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve:$(TAG) quay.io/docling-project/docling-serve:$(BRANCH_TAG)
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load -f Containerfile -t $(IMAGE_ORG_GHCR)/docling-serve:$(TAG) .
+	$(call tag_branch_aliases,docling-serve)
 
 .PHONY: docling-serve-cpu-image
 docling-serve-cpu-image: Containerfile ## Build docling-serve "cpu only" container image
 	$(ECHO_PREFIX) printf "  %-12s Containerfile\n" "[docling-serve CPU]"
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group cpu --no-extra flash-attn" -f Containerfile -t ghcr.io/docling-project/docling-serve-cpu:$(TAG) .
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-cpu:$(TAG) ghcr.io/docling-project/docling-serve-cpu:$(BRANCH_TAG)
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-cpu:$(TAG) quay.io/docling-project/docling-serve-cpu:$(BRANCH_TAG)
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group cpu --no-extra flash-attn" -f Containerfile -t $(IMAGE_ORG_GHCR)/docling-serve-cpu:$(TAG) .
+	$(call tag_branch_aliases,docling-serve-cpu)
+
+.PHONY: docling-serve-surya-image
+docling-serve-surya-image: Containerfile ## Build docling-serve container image with Surya OCR plugin
+	$(ECHO_PREFIX) printf "  %-12s Containerfile\n" "[docling-serve + Surya]"
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "DOCLING_EXTRA_PLUGINS=$(SURYA_EXTRA_PLUGINS)" -f Containerfile -t $(IMAGE_ORG_GHCR)/docling-serve-surya:$(TAG) .
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag $(IMAGE_ORG_GHCR)/docling-serve-surya:$(TAG) $(IMAGE_ORG_GHCR)/docling-serve-surya:$(BRANCH_TAG)
 
 .PHONY: docling-serve-cu124-image
 docling-serve-cu124-image: Containerfile ## Build docling-serve container image with CUDA 12.4 support
 	$(ECHO_PREFIX) printf "  %-12s Containerfile\n" "[docling-serve with Cuda 12.4]"
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group cu124" -f Containerfile --platform linux/amd64 -t ghcr.io/docling-project/docling-serve-cu124:$(TAG) .
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-cu124:$(TAG) ghcr.io/docling-project/docling-serve-cu124:$(BRANCH_TAG)
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-cu124:$(TAG) quay.io/docling-project/docling-serve-cu124:$(BRANCH_TAG)
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group cu124" -f Containerfile --platform linux/amd64 -t $(IMAGE_ORG_GHCR)/docling-serve-cu124:$(TAG) .
+	$(call tag_branch_aliases,docling-serve-cu124)
 
 .PHONY: docling-serve-cu126-image
 docling-serve-cu126-image: Containerfile ## Build docling-serve container image with CUDA 12.6 support
 	$(ECHO_PREFIX) printf "  %-12s Containerfile\n" "[docling-serve with Cuda 12.6]"
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group cu126" -f Containerfile --platform linux/amd64 -t ghcr.io/docling-project/docling-serve-cu126:$(TAG) .
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-cu126:$(TAG) ghcr.io/docling-project/docling-serve-cu126:$(BRANCH_TAG)
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-cu126:$(TAG) quay.io/docling-project/docling-serve-cu126:$(BRANCH_TAG)
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group cu126" -f Containerfile --platform linux/amd64 -t $(IMAGE_ORG_GHCR)/docling-serve-cu126:$(TAG) .
+	$(call tag_branch_aliases,docling-serve-cu126)
 
 .PHONY: docling-serve-cu128-image
 docling-serve-cu128-image: Containerfile ## Build docling-serve container image with CUDA 12.8 support
 	$(ECHO_PREFIX) printf "  %-12s Containerfile\n" "[docling-serve with Cuda 12.8]"
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group cu128" -f Containerfile --platform linux/amd64 -t ghcr.io/docling-project/docling-serve-cu128:$(TAG) .
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-cu128:$(TAG) ghcr.io/docling-project/docling-serve-cu128:$(BRANCH_TAG)
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-cu128:$(TAG) quay.io/docling-project/docling-serve-cu128:$(BRANCH_TAG)
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group cu128" -f Containerfile --platform linux/amd64 -t $(IMAGE_ORG_GHCR)/docling-serve-cu128:$(TAG) .
+	$(call tag_branch_aliases,docling-serve-cu128)
+
+.PHONY: docling-serve-cu128-surya-image
+docling-serve-cu128-surya-image: Containerfile ## Build docling-serve CUDA 12.8 image with Surya OCR plugin
+	$(ECHO_PREFIX) printf "  %-12s Containerfile\n" "[docling-serve Cuda 12.8 + Surya]"
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group cu128 --no-extra flash-attn" --build-arg "DOCLING_EXTRA_PLUGINS=$(SURYA_EXTRA_PLUGINS)" -f Containerfile --platform linux/amd64 -t $(IMAGE_ORG_GHCR)/docling-serve-cu128-surya:$(TAG) .
+	$(call tag_branch_aliases,docling-serve-cu128-surya)
 
 .PHONY: docling-serve-cu130-image
 docling-serve-cu130-image: Containerfile ## Build docling-serve container image with CUDA 13.0 support
 	$(ECHO_PREFIX) printf "  %-12s Containerfile\n" "[docling-serve with Cuda 13.0]"
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group cu130" -f Containerfile --platform linux/amd64 -t ghcr.io/docling-project/docling-serve-cu130:$(TAG) .
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-cu130:$(TAG) ghcr.io/docling-project/docling-serve-cu130:$(BRANCH_TAG)
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-cu130:$(TAG) quay.io/docling-project/docling-serve-cu130:$(BRANCH_TAG)
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group cu130" -f Containerfile --platform linux/amd64 -t $(IMAGE_ORG_GHCR)/docling-serve-cu130:$(TAG) .
+	$(call tag_branch_aliases,docling-serve-cu130)
+
+.PHONY: docling-serve-cu130-surya-image
+docling-serve-cu130-surya-image: Containerfile ## Build docling-serve CUDA 13.0 image with Surya OCR plugin
+	$(ECHO_PREFIX) printf "  %-12s Containerfile\n" "[docling-serve Cuda 13.0 + Surya]"
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group cu130 --no-extra flash-attn" --build-arg "DOCLING_EXTRA_PLUGINS=$(SURYA_EXTRA_PLUGINS)" -f Containerfile --platform linux/amd64 -t $(IMAGE_ORG_GHCR)/docling-serve-cu130-surya:$(TAG) .
+	$(call tag_branch_aliases,docling-serve-cu130-surya)
 
 .PHONY: docling-serve-rocm-image
 docling-serve-rocm-image: Containerfile ## Build docling-serve container image with ROCm support
 	$(ECHO_PREFIX) printf "  %-12s Containerfile\n" "[docling-serve with ROCm 6.3]"
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group rocm --no-extra flash-attn" -f Containerfile --platform linux/amd64 -t ghcr.io/docling-project/docling-serve-rocm:$(TAG) .
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-rocm:$(TAG) ghcr.io/docling-project/docling-serve-rocm:$(BRANCH_TAG)
-	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-rocm:$(TAG) quay.io/docling-project/docling-serve-rocm:$(BRANCH_TAG)
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group rocm --no-extra flash-attn" -f Containerfile --platform linux/amd64 -t $(IMAGE_ORG_GHCR)/docling-serve-rocm:$(TAG) .
+	$(call tag_branch_aliases,docling-serve-rocm)
 
 .PHONY: action-lint
 action-lint: .action-lint ##      Lint GitHub Action workflows

--- a/docling_serve/gradio_ui.py
+++ b/docling_serve/gradio_ui.py
@@ -21,6 +21,7 @@ from docling.datamodel.pipeline_options import (
     TableFormerMode,
     TableStructureOptions,
 )
+from docling.models.factories import get_ocr_factory
 
 from docling_serve.helper_functions import _to_list_of_strings
 from docling_serve.settings import docling_serve_settings, uvicorn_settings
@@ -236,6 +237,26 @@ def change_ocr_lang(ocr_engine):
         return gr.update(visible=True, value="fr-FR,de-DE,es-ES,en-US")
 
     return gr.update(visible=False, value="")
+
+
+def _build_ocr_engines_list() -> list[tuple[str, str]]:
+    # Load OCR kinds from the runtime factory so external plugins are available in UI.
+    try:
+        factory = get_ocr_factory(
+            allow_external_plugins=docling_serve_settings.allow_external_plugins
+        )
+        kinds = sorted(str(kind) for kind in factory.registered_kind)
+    except Exception:
+        kinds = ["auto", "easyocr", "tesseract", "rapidocr"]
+
+    if "auto" in kinds:
+        kinds = ["auto"] + [k for k in kinds if k != "auto"]
+
+    labels = []
+    for kind in kinds:
+        label = "Auto" if kind == "auto" else kind.replace("_", " ").title()
+        labels.append((label, kind))
+    return labels
 
 
 def wait_task_finish(auth: str, task_id: str, return_as_file: bool):
@@ -695,15 +716,7 @@ with gr.Blocks(
                 ocr = gr.Checkbox(label="Enable OCR", value=True)
                 force_ocr = gr.Checkbox(label="Force OCR", value=False)
             with gr.Column(scale=1):
-                engines_list = [
-                    ("Auto", "auto"),
-                    ("EasyOCR", "easyocr"),
-                    ("Tesseract", "tesseract"),
-                    ("RapidOCR", "rapidocr"),
-                ]
-                if sys.platform == "darwin":
-                    engines_list.append(("OCRMac", "ocrmac"))
-
+                engines_list = _build_ocr_engines_list()
                 ocr_engine = gr.Radio(
                     engines_list,
                     label="OCR Engine",

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -303,6 +303,9 @@ class DoclingServeSettings(BaseSettings):
     custom_layout_presets: dict[str, Any] = Field(default_factory=dict)
 
     # OCR Control
+    # Deprecated alias for backward compatibility. If set, it overrides
+    # default_ocr_kind/default_ocr_preset when they are left on "auto".
+    ocr_engine: Optional[str] = None
     default_ocr_preset: str = "auto"
     default_ocr_kind: str = "auto"
     allowed_ocr_presets: Optional[list[str]] = None
@@ -405,6 +408,12 @@ class DoclingServeSettings(BaseSettings):
 
     @model_validator(mode="after")
     def engine_settings(self) -> Self:
+        if self.ocr_engine:
+            if self.default_ocr_kind == "auto":
+                self.default_ocr_kind = self.ocr_engine
+            if self.default_ocr_preset == "auto":
+                self.default_ocr_preset = self.ocr_engine
+
         # Validate KFP engine settings
         if self.eng_kind == AsyncEngine.KFP:
             if self.eng_kfp_endpoint is None:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,7 @@ THe following table describes the options to configure the Docling Serve app.
 |  | `DOCLING_SERVE_SHOW_VERSION_INFO` | `true` | If enabled, the `/version` endpoint will provide the Docling package versions, otherwise it will return a forbidden 403 error. |
 |  | `DOCLING_SERVE_ENABLE_REMOTE_SERVICES` | `false` | Allow pipeline components making remote connections. For example, this is needed when using a vision-language model via APIs. |
 |  | `DOCLING_SERVE_ALLOW_EXTERNAL_PLUGINS` | `false` | Allow the selection of third-party plugins. |
+|  | `DOCLING_SERVE_OCR_ENGINE` | unset | Deprecated compatibility alias. When set, it is used as fallback for both `DOCLING_SERVE_DEFAULT_OCR_KIND` and `DOCLING_SERVE_DEFAULT_OCR_PRESET` if those are still `auto`. |
 |  | `DOCLING_SERVE_ALLOW_CUSTOM_VLM_CONFIG` | `false` | Allow users to specify a fully custom VLM pipeline configuration (`vlm_pipeline_custom_config`). When `false`, only presets are accepted. |
 |  | `DOCLING_SERVE_ALLOW_CUSTOM_PICTURE_DESCRIPTION_CONFIG` | `false` | Allow users to specify a fully custom picture description configuration. When `false`, only presets are accepted. |
 |  | `DOCLING_SERVE_ALLOW_CUSTOM_CODE_FORMULA_CONFIG` | `false` | Allow users to specify a fully custom code/formula configuration. When `false`, only presets are accepted. |
@@ -130,6 +131,17 @@ The following options control the behavior of the Docling converter, including p
 | `DOCLING_SERVE_DEFAULT_LAYOUT_PRESET` | `docling_layout_default` | Default layout preset to use when user specifies "default". |
 | `DOCLING_SERVE_ALLOWED_LAYOUT_PRESETS` | `null` (all allowed) | List of allowed layout preset IDs. Accepts JSON array or comma-separated string. |
 | `DOCLING_SERVE_CUSTOM_LAYOUT_PRESETS` | `{}` | Custom layout presets. Must be a JSON object mapping preset IDs to layout options with 'kind' field. |
+
+#### OCR Control
+
+| ENV | Default | Description |
+| ----|---------|-------------|
+| `DOCLING_SERVE_DEFAULT_OCR_KIND` | `auto` | Default OCR kind used when request doesn't set OCR explicitly. |
+| `DOCLING_SERVE_DEFAULT_OCR_PRESET` | `auto` | Default OCR preset used when request doesn't set OCR explicitly. |
+| `DOCLING_SERVE_ALLOWED_OCR_KINDS` | `null` (all allowed) | List of allowed OCR kinds. Accepts JSON array or comma-separated string. |
+| `DOCLING_SERVE_ALLOWED_OCR_PRESETS` | `null` (all allowed) | List of allowed OCR preset IDs. Accepts JSON array or comma-separated string. |
+| `DOCLING_SERVE_CUSTOM_OCR_PRESETS` | `{}` | Custom OCR presets. Must be a JSON object. |
+| `DOCLING_SERVE_ALLOW_CUSTOM_OCR_CONFIG` | `false` | Whether users can specify custom OCR configuration payloads. |
 
 **Configuration Examples:**
 

--- a/tests/test_env_parsing.py
+++ b/tests/test_env_parsing.py
@@ -51,3 +51,23 @@ def test_default_values():
 
     assert settings.allowed_vlm_presets is None
     assert settings.custom_vlm_presets == {}
+
+
+def test_ocr_engine_alias_sets_defaults(monkeypatch):
+    """Deprecated DOCLING_SERVE_OCR_ENGINE should set OCR defaults."""
+    monkeypatch.setenv("DOCLING_SERVE_OCR_ENGINE", "suryaocr")
+
+    settings = DoclingServeSettings()
+    assert settings.default_ocr_kind == "suryaocr"
+    assert settings.default_ocr_preset == "suryaocr"
+
+
+def test_ocr_engine_alias_does_not_override_explicit_defaults(monkeypatch):
+    """Explicit OCR defaults should win over deprecated alias."""
+    monkeypatch.setenv("DOCLING_SERVE_OCR_ENGINE", "suryaocr")
+    monkeypatch.setenv("DOCLING_SERVE_DEFAULT_OCR_KIND", "easyocr")
+    monkeypatch.setenv("DOCLING_SERVE_DEFAULT_OCR_PRESET", "rapidocr")
+
+    settings = DoclingServeSettings()
+    assert settings.default_ocr_kind == "easyocr"
+    assert settings.default_ocr_preset == "rapidocr"


### PR DESCRIPTION
Adds support for building Docling Serve container images with external Docling plugins installed at image build time, and introduces Surya OCR image targets.

Changes included:

- add `DOCLING_EXTRA_PLUGINS` build arg in `Containerfile`
- add Surya image targets for base, CUDA 12.8, and CUDA 13.0 builds
- add reusable image organization variables and branch tag aliasing in `Makefile`
- exclude `flash-attn` from Surya CUDA image targets to avoid runtime failures when the compiled `flash_attn_2_cuda` extension is unavailable
- discover OCR engines dynamically in the Gradio UI so external OCR plugins appear automatically
- add deprecated `DOCLING_SERVE_OCR_ENGINE` compatibility alias for OCR defaults
- document OCR control environment variables and update `.env.example`
- add tests for OCR env alias behavior

Testing performed:

- built and ran `docling-serve-cu128-surya-image` locally
- verified Surya OCR works in the rebuilt CUDA 12.8 image
- verified the rebuilt image does not include `flash_attn` / `flash_attn_2_cuda`
- added unit tests for `DOCLING_SERVE_OCR_ENGINE` fallback behavior