### PR TITLE
feat(rq): Wire Redis Sentinel support through to RQ engine

### DIFF
--- a/docling_serve/__main__.py
+++ b/docling_serve/__main__.py
@@ -416,6 +416,14 @@ def rq_worker() -> Any:
         redis_gate_reserved_connections=docling_serve_settings.eng_rq_redis_gate_reserved_connections,
         redis_gate_wait_timeout=docling_serve_settings.eng_rq_redis_gate_wait_timeout,
         redis_gate_status_poll_wait_timeout=docling_serve_settings.eng_rq_redis_gate_status_poll_wait_timeout,
+        redis_sentinel_hosts=docling_serve_settings.eng_rq_redis_sentinel_hosts,
+        redis_sentinel_service_name=docling_serve_settings.eng_rq_redis_sentinel_service_name,
+        redis_sentinel_db=docling_serve_settings.eng_rq_redis_sentinel_db,
+        redis_sentinel_username=docling_serve_settings.eng_rq_redis_sentinel_username,
+        redis_sentinel_password=docling_serve_settings.eng_rq_redis_sentinel_password,
+        redis_sentinel_auth_username=docling_serve_settings.eng_rq_redis_sentinel_auth_username,
+        redis_sentinel_auth_password=docling_serve_settings.eng_rq_redis_sentinel_auth_password,
+        redis_sentinel_ssl=docling_serve_settings.eng_rq_redis_sentinel_ssl,
     )
 
     cm_config = DoclingConverterManagerConfig(

--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -256,11 +256,15 @@ def create_app():  # noqa: C901
             )
 
     # Setup OpenTelemetry instrumentation
-    redis_url = (
-        docling_serve_settings.eng_rq_redis_url
-        if docling_serve_settings.eng_kind == AsyncEngine.RQ
-        else None
-    )
+    # Reuse the RQ orchestrator's existing Redis client so the metrics
+    # collector follows the same Sentinel/auth/SSL routing.
+    rq_redis_connection = None
+    if docling_serve_settings.eng_kind == AsyncEngine.RQ:
+        from docling_jobkit.orchestrators.rq.orchestrator import RQOrchestrator
+
+        orchestrator = get_async_orchestrator()
+        assert isinstance(orchestrator, RQOrchestrator)
+        rq_redis_connection = orchestrator._redis_conn
 
     # Get Ray redis_manager if using Ray engine
     ray_redis_manager = None
@@ -278,7 +282,7 @@ def create_app():  # noqa: C901
         enable_traces=docling_serve_settings.otel_enable_traces,
         enable_prometheus=docling_serve_settings.otel_enable_prometheus,
         enable_otlp_metrics=docling_serve_settings.otel_enable_otlp_metrics,
-        redis_url=redis_url,
+        rq_redis_connection=rq_redis_connection,
         metrics_port=docling_serve_settings.metrics_port,
         ray_redis_manager=ray_redis_manager,
     )

--- a/docling_serve/orchestrator_factory.py
+++ b/docling_serve/orchestrator_factory.py
@@ -114,6 +114,14 @@ def get_async_orchestrator() -> BaseOrchestrator:
             zombie_reaper_interval=docling_serve_settings.eng_rq_zombie_reaper_interval,
             zombie_reaper_max_age=docling_serve_settings.eng_rq_zombie_reaper_max_age,
             result_removal_delay=docling_serve_settings.result_removal_delay,
+            redis_sentinel_hosts=docling_serve_settings.eng_rq_redis_sentinel_hosts,
+            redis_sentinel_service_name=docling_serve_settings.eng_rq_redis_sentinel_service_name,
+            redis_sentinel_db=docling_serve_settings.eng_rq_redis_sentinel_db,
+            redis_sentinel_username=docling_serve_settings.eng_rq_redis_sentinel_username,
+            redis_sentinel_password=docling_serve_settings.eng_rq_redis_sentinel_password,
+            redis_sentinel_auth_username=docling_serve_settings.eng_rq_redis_sentinel_auth_username,
+            redis_sentinel_auth_password=docling_serve_settings.eng_rq_redis_sentinel_auth_password,
+            redis_sentinel_ssl=docling_serve_settings.eng_rq_redis_sentinel_ssl,
         )
 
         orchestrator = RQOrchestrator(config=rq_config)

--- a/docling_serve/otel_instrumentation.py
+++ b/docling_serve/otel_instrumentation.py
@@ -68,7 +68,7 @@ def setup_otel_instrumentation(
     enable_traces: bool = True,
     enable_prometheus: bool = True,
     enable_otlp_metrics: bool = False,
-    redis_url: str | None = None,
+    rq_redis_connection: Redis | None = None,
     metrics_port: int | None = None,
     ray_redis_manager=None,
 ):
@@ -82,7 +82,9 @@ def setup_otel_instrumentation(
         enable_traces: Enable OTEL traces
         enable_prometheus: Enable Prometheus metrics export
         enable_otlp_metrics: Enable OTLP metrics export (for OTEL collector)
-        redis_url: Redis URL for RQ metrics (if using RQ engine)
+        rq_redis_connection: Redis client for RQ metrics (if using RQ engine).
+            Pass the orchestrator's existing client so Sentinel/SSL/auth
+            settings are honoured without duplicating connection logic.
         metrics_port: If set, start a separate HTTP server on this port for /metrics
         ray_redis_manager: RedisStateManager instance for Ray metrics (if using Ray engine)
     """
@@ -140,11 +142,10 @@ def setup_otel_instrumentation(
     )
     FastAPIInstrumentor.instrument_app(app, excluded_urls=excluded_urls)
 
-    # Register RQ metrics if Redis URL is provided
-    if redis_url and enable_prometheus:
-        logger.info(f"Registering RQ metrics collector for Redis at {redis_url}")
-        connection = Redis.from_url(redis_url)
-        REGISTRY.register(RQCollector(connection))
+    # Register RQ metrics if a Redis client is provided
+    if rq_redis_connection is not None and enable_prometheus:
+        logger.info("Registering RQ metrics collector")
+        REGISTRY.register(RQCollector(rq_redis_connection))
 
     # Register Ray metrics if RedisStateManager is provided
     if ray_redis_manager and enable_prometheus:

--- a/docling_serve/rq_metrics_collector.py
+++ b/docling_serve/rq_metrics_collector.py
@@ -4,15 +4,10 @@ import logging
 from prometheus_client import Summary
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 from prometheus_client.registry import Collector
-from redis import Redis
 from rq import Queue, Worker
 from rq.job import JobStatus
 
 logger = logging.getLogger(__name__)
-
-
-def get_redis_connection(url: str):
-    return Redis.from_url(url)
 
 
 def get_workers_stats(connection):

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -157,6 +157,18 @@ class DoclingServeSettings(BaseSettings):
     eng_rq_redis_gate_status_poll_wait_timeout: float = 5.0
     eng_rq_zombie_reaper_interval: float = 300.0
     eng_rq_zombie_reaper_max_age: float = 3600.0
+    # RQ Redis Sentinel. When `eng_rq_redis_sentinel_hosts` and
+    # `eng_rq_redis_sentinel_service_name` are both set, all RQ Redis clients
+    # route through Sentinel and `eng_rq_redis_url` is ignored. Hosts are
+    # `host[:port]` strings; default Sentinel port is 26379.
+    eng_rq_redis_sentinel_hosts: Optional[list[str]] = None
+    eng_rq_redis_sentinel_service_name: Optional[str] = None
+    eng_rq_redis_sentinel_db: int = 0
+    eng_rq_redis_sentinel_username: Optional[str] = None
+    eng_rq_redis_sentinel_password: Optional[str] = None
+    eng_rq_redis_sentinel_auth_username: Optional[str] = None
+    eng_rq_redis_sentinel_auth_password: Optional[str] = None
+    eng_rq_redis_sentinel_ssl: bool = False
     # KFP engine
     eng_kfp_endpoint: Optional[AnyUrl] = None
     eng_kfp_token: Optional[str] = None
@@ -417,8 +429,19 @@ class DoclingServeSettings(BaseSettings):
                 )
 
         if self.eng_kind == AsyncEngine.RQ:
-            if not self.eng_rq_redis_url:
-                raise ValueError("RQ Redis url is required when using the RQ engine.")
+            sentinel_hosts = self.eng_rq_redis_sentinel_hosts
+            sentinel_service = self.eng_rq_redis_sentinel_service_name
+            if bool(sentinel_hosts) ^ bool(sentinel_service):
+                raise ValueError(
+                    "DOCLING_SERVE_ENG_RQ_REDIS_SENTINEL_HOSTS and "
+                    "DOCLING_SERVE_ENG_RQ_REDIS_SENTINEL_SERVICE_NAME must be set together."
+                )
+            if not (sentinel_hosts and sentinel_service) and not self.eng_rq_redis_url:
+                raise ValueError(
+                    "When using the RQ engine, set either DOCLING_SERVE_ENG_RQ_REDIS_URL "
+                    "or both DOCLING_SERVE_ENG_RQ_REDIS_SENTINEL_HOSTS and "
+                    "DOCLING_SERVE_ENG_RQ_REDIS_SENTINEL_SERVICE_NAME."
+                )
 
         if self.eng_kind == AsyncEngine.RAY:
             if not self.eng_ray_redis_url:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,7 @@ pytorch-triton-rocm = [
   { index = "pytorch-rocm", marker = "sys_platform == 'linux'" },
 ]
 
-# docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "main" }
+docling-jobkit = { git = "https://github.com/doctorgpt-corp/docling-jobkit", rev = "feat/redis-sentinel-rq" }
 # docling = { git = "https://github.com/docling-project/docling/", rev = "main" }
 # docling-jobkit = { path = "../docling-jobkit", editable = true }
 

--- a/tests/test_redis_sentinel_settings.py
+++ b/tests/test_redis_sentinel_settings.py
@@ -1,0 +1,60 @@
+"""Tests for RQ Redis Sentinel configuration in docling-serve."""
+
+import pytest
+from pydantic import ValidationError
+
+from docling_serve.settings import AsyncEngine, DoclingServeSettings
+
+
+class TestRedisSentinelSettings:
+    def test_url_only_config_is_valid(self):
+        settings = DoclingServeSettings(
+            eng_kind=AsyncEngine.RQ,
+            eng_rq_redis_url="redis://localhost:6379/",
+        )
+        assert settings.eng_rq_redis_sentinel_hosts is None
+        assert settings.eng_rq_redis_sentinel_service_name is None
+
+    def test_sentinel_only_config_is_valid(self):
+        settings = DoclingServeSettings(
+            eng_kind=AsyncEngine.RQ,
+            eng_rq_redis_sentinel_hosts=["s1:26379", "s2:26379"],
+            eng_rq_redis_sentinel_service_name="mymaster",
+            eng_rq_redis_sentinel_password="secret",
+            eng_rq_redis_sentinel_db=2,
+        )
+        assert settings.eng_rq_redis_url == ""
+        assert settings.eng_rq_redis_sentinel_hosts == ["s1:26379", "s2:26379"]
+        assert settings.eng_rq_redis_sentinel_service_name == "mymaster"
+        assert settings.eng_rq_redis_sentinel_db == 2
+
+    def test_neither_url_nor_sentinel_rejected(self):
+        with pytest.raises(ValidationError, match="ENG_RQ_REDIS_URL"):
+            DoclingServeSettings(eng_kind=AsyncEngine.RQ)
+
+    def test_partial_sentinel_config_rejected(self):
+        with pytest.raises(ValidationError, match="must be set together"):
+            DoclingServeSettings(
+                eng_kind=AsyncEngine.RQ,
+                eng_rq_redis_url="redis://localhost:6379/",
+                eng_rq_redis_sentinel_hosts=["s1:26379"],
+            )
+
+        with pytest.raises(ValidationError, match="must be set together"):
+            DoclingServeSettings(
+                eng_kind=AsyncEngine.RQ,
+                eng_rq_redis_url="redis://localhost:6379/",
+                eng_rq_redis_sentinel_service_name="mymaster",
+            )
+
+    def test_both_url_and_sentinel_accepted(self):
+        # The Sentinel config wins at the orchestrator layer; we still allow
+        # both fields so users can flip between them via env vars without
+        # rewriting their settings file.
+        settings = DoclingServeSettings(
+            eng_kind=AsyncEngine.RQ,
+            eng_rq_redis_url="redis://localhost:6379/",
+            eng_rq_redis_sentinel_hosts=["s1:26379"],
+            eng_rq_redis_sentinel_service_name="mymaster",
+        )
+        assert settings.eng_rq_redis_sentinel_hosts == ["s1:26379"]


### PR DESCRIPTION
## Summary

Surfaces the Redis Sentinel support added in [docling-project/docling-jobkit#138](https://github.com/docling-project/docling-jobkit/pull/138) through to the docling-serve settings layer. RQ deployments backed by a Sentinel-fronted HA Redis can now configure docling-serve directly via environment variables; the existing `DOCLING_SERVE_ENG_RQ_REDIS_URL` path is unchanged.

## Configuration

Eight new settings, all optional:

| Setting | Env var |
|---------|---------|
| `eng_rq_redis_sentinel_hosts: list[str]` | `DOCLING_SERVE_ENG_RQ_REDIS_SENTINEL_HOSTS` (JSON array or CSV) |
| `eng_rq_redis_sentinel_service_name: str` | `DOCLING_SERVE_ENG_RQ_REDIS_SENTINEL_SERVICE_NAME` |
| `eng_rq_redis_sentinel_db: int = 0` | `DOCLING_SERVE_ENG_RQ_REDIS_SENTINEL_DB` |
| `eng_rq_redis_sentinel_username` / `_password` | Credentials for the Redis master |
| `eng_rq_redis_sentinel_auth_username` / `_auth_password` | Credentials for the Sentinel daemons themselves |
| `eng_rq_redis_sentinel_ssl: bool = False` | TLS to the master |

A model validator enforces that `hosts` and `service_name` are set together, and that the RQ engine has either a URL or a complete Sentinel config.

### Example

```bash
export DOCLING_SERVE_ENG_KIND=rq
export DOCLING_SERVE_ENG_RQ_REDIS_SENTINEL_HOSTS='["sentinel-1:26379","sentinel-2:26379","sentinel-3:26379"]'
export DOCLING_SERVE_ENG_RQ_REDIS_SENTINEL_SERVICE_NAME=mymaster
export DOCLING_SERVE_ENG_RQ_REDIS_SENTINEL_PASSWORD=redis-master-password
# Optional: separate credentials for the Sentinel daemons themselves
export DOCLING_SERVE_ENG_RQ_REDIS_SENTINEL_AUTH_PASSWORD=sentinel-daemon-password
```

## Wiring

- `settings.py` — adds the eight fields and a validator that allows either `eng_rq_redis_url` or a complete Sentinel config.
- `orchestrator_factory.py`, `__main__.py` — pass the new fields through to `RQOrchestratorConfig`.
- `app.py` + `otel_instrumentation.py` — replace the `redis_url` parameter with `rq_redis_connection`. The Prometheus `RQCollector` now reuses the orchestrator's existing Redis client, so it automatically inherits Sentinel/auth/SSL routing without reconstructing a connection from a URL string. Removes the now-dead `get_redis_connection` helper from `rq_metrics_collector.py`.
- `pyproject.toml` / `uv.lock` — temporary pin to `git+https://github.com/doctorgpt-corp/docling-jobkit@feat/redis-sentinel-rq`.

## Tests

`tests/test_redis_sentinel_settings.py` covers the settings validation matrix:

| #   | Scenario                          | What it proves                                                                                                            |
| --- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
| 1   | URL-only config valid             | Existing deployments are unaffected                                                                                       |
| 2   | Sentinel-only config valid        | New env vars parse correctly, defaults stick                                                                              |
| 3   | Neither URL nor Sentinel rejected | RQ engine still requires *some* Redis config                                                                              |
| 4   | Partial Sentinel config rejected  | Mismatched `hosts` without `service_name` (and vice versa) raises `ValidationError`                                       |
| 5   | Both URL and Sentinel accepted    | Allows flipping between the two via env vars without rewriting the settings file; Sentinel wins at the orchestrator layer |

End-to-end Sentinel routing was validated locally against a real cluster.

<details>
<summary><code>tests/sentinel-fixture/docker-compose.yml</code> (1 master + 1 replica + 3 sentinels, quorum 2)</summary>

```yaml
services:
  redis-master:
    image: bitnami/redis:latest
    environment:
      REDIS_REPLICATION_MODE: master
      REDIS_PASSWORD: testpass
      REDIS_MASTER_PASSWORD: testpass
      ALLOW_EMPTY_PASSWORD: "no"
    ports: ["16379:6379"]
    healthcheck:
      test: ["CMD", "redis-cli", "-a", "testpass", "PING"]
      interval: 1s
      timeout: 3s
      retries: 30

  redis-replica:
    image: bitnami/redis:latest
    environment:
      REDIS_REPLICATION_MODE: slave
      REDIS_MASTER_HOST: redis-master
      REDIS_MASTER_PORT_NUMBER: "6379"
      REDIS_MASTER_PASSWORD: testpass
      REDIS_PASSWORD: testpass
      ALLOW_EMPTY_PASSWORD: "no"
    depends_on: { redis-master: { condition: service_healthy } }
    healthcheck:
      test: ["CMD", "redis-cli", "-a", "testpass", "PING"]
      interval: 1s
      timeout: 3s
      retries: 30

  sentinel-1: &sentinel
    image: bitnami/redis-sentinel:latest
    environment:
      REDIS_MASTER_HOST: redis-master
      REDIS_MASTER_PORT_NUMBER: "6379"
      REDIS_MASTER_SET: mymaster
      REDIS_MASTER_PASSWORD: testpass
      REDIS_SENTINEL_QUORUM: "2"
      REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS: "5000"
      REDIS_SENTINEL_FAILOVER_TIMEOUT: "10000"
    ports: ["26379:26379"]
    depends_on: { redis-master: { condition: service_healthy } }
    healthcheck:
      test: ["CMD", "redis-cli", "-p", "26379", "PING"]
      interval: 1s
      timeout: 3s
      retries: 30
  sentinel-2: { <<: *sentinel, ports: ["26380:26379"] }
  sentinel-3: { <<: *sentinel, ports: ["26381:26379"] }
```

</details>

Scenarios validated against the cluster above (all passed):

| #   | Scenario                                         | What it proved                                                                                                 |
| --- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
| 1   | Sync `make_sync_redis` SET/GET via Sentinel      | Pool is a `SentinelConnectionPool`, master accepts r/w                                                         |
| 2   | Async `make_async_redis` SET/GET via Sentinel    | Same for the async pool                                                                                        |
| 3   | `RQOrchestrator.check_connection()` via Sentinel | Full orchestrator init + `PING` + clean `close()`                                                              |
| 4   | Master role assertion                            | `info("replication")["role"] == "master"` — Sentinel discovery returns the actual master, not a replica        |
| 5   | RQ Queue + SimpleWorker round-trip via Sentinel  | Enqueue → drain → fetch result; RQ's own queue/registry/result paths all work through `SentinelConnectionPool` |
| 6   | URL-path regression                              | `redis://` config path unchanged                                                                               |

## Out of scope

- Ray engine: see jobkit PR — Ray's existing "Sentinel via URL" docs are inaccurate and the implementation needs separate work.