### PR TITLE
docs: Fix docker pull README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following container images are available for running **Docling Serve** with 
 >
 > ```bash
 > # ✅ Recommended: Explicit version
-> docker pull quay.io/docling-project/docling-serve-cu130:1.12.0
+> docker pull quay.io/docling-project/docling-serve-cu130:v1.18.0
 >
 > # ❌ Not available for CUDA images
 > docker pull quay.io/docling-project/docling-serve-cu130:latest


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

**Description**
Fix docker pull README.md example. The docling docker images have the `v` prefix and the version `1.12.0` has no images for the `-cu130` suffix (see [here](https://quay.io/repository/docling-project/docling-serve-cu130?tab=tags)).

**Issue resolved by this Pull Request:**
Resolves #594

