### PR TITLE
feat: Control error detail of public API responses 

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -104,6 +104,7 @@ from docling_serve.policy import (
     validate_convert_options,
     validate_convert_request,
 )
+from docling_serve.public_errors import build_public_http_detail
 from docling_serve.response_preparation import prepare_response
 from docling_serve.settings import AsyncEngine, docling_serve_settings
 from docling_serve.storage import get_scratch
@@ -273,7 +274,13 @@ def create_app():  # noqa: C901
             del request
             return JSONResponse(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                content={"detail": str(exc) or "Ray dispatcher is unavailable."},
+                content={
+                    "detail": build_public_http_detail(
+                        exc=exc,
+                        debug_enabled=docling_serve_settings.debug_error_details,
+                        fallback_message="Ray dispatcher is unavailable.",
+                    )
+                },
                 headers={"Retry-After": "1"},
             )
 
@@ -660,7 +667,11 @@ def create_app():  # noqa: C901
         except Exception as exc:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail=str(exc) or "Readiness check failed",
+                detail=build_public_http_detail(
+                    exc=exc,
+                    debug_enabled=docling_serve_settings.debug_error_details,
+                    fallback_message="Readiness check failed",
+                ),
             ) from exc
 
         return ReadinessResponse()
@@ -1344,7 +1355,12 @@ def create_app():  # noqa: C901
             raise HTTPException(status_code=404, detail="Task not found.")
         except ProgressInvalid as err:
             raise HTTPException(
-                status_code=400, detail=f"Invalid progress payload: {err}"
+                status_code=400,
+                detail=build_public_http_detail(
+                    exc=err,
+                    debug_enabled=docling_serve_settings.debug_error_details,
+                    fallback_message="Invalid progress payload.",
+                ),
             )
 
     #### Clear requests

--- a/docling_serve/orchestrator_factory.py
+++ b/docling_serve/orchestrator_factory.py
@@ -102,6 +102,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             results_prefix=docling_serve_settings.eng_rq_results_prefix,
             sub_channel=docling_serve_settings.eng_rq_sub_channel,
             scratch_dir=get_scratch(),
+            debug_error_details=docling_serve_settings.debug_error_details,
             results_ttl=docling_serve_settings.eng_rq_results_ttl,
             failure_ttl=docling_serve_settings.eng_rq_failure_ttl,
             redis_max_connections=docling_serve_settings.eng_rq_redis_max_connections,
@@ -293,6 +294,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             scratch_dir=docling_serve_settings.eng_ray_scratch_dir or get_scratch(),
             # Logging
             log_level=docling_serve_settings.eng_ray_log_level,
+            debug_error_details=docling_serve_settings.debug_error_details,
         )
 
         return RayOrchestrator(config=ray_config, converter_manager=cm)

--- a/docling_serve/public_errors.py
+++ b/docling_serve/public_errors.py
@@ -1,0 +1,10 @@
+def build_public_http_detail(
+    exc: BaseException,
+    debug_enabled: bool,
+    fallback_message: str,
+) -> str:
+    if not debug_enabled:
+        return fallback_message
+
+    detail = str(exc)
+    return detail or fallback_message

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -126,6 +126,7 @@ class DoclingServeSettings(BaseSettings):
     allow_custom_ocr_config: bool = False
     show_version_info: bool = True
     enable_management_endpoints: bool = False
+    debug_error_details: bool = False
 
     api_key: str = ""
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,7 @@ THe following table describes the options to configure the Docling Serve app.
 | `--enable-ui` | `DOCLING_SERVE_ENABLE_UI` | `false` | Enable the demonstrator UI. |
 |  | `DOCLING_SERVE_ENABLE_MANAGEMENT_ENDPOINTS` | `false` | If enabled, the `/v1/memory` endpoints will provide memory statistics, otherwise it will return a forbidden 403 error. |
 |  | `DOCLING_SERVE_SHOW_VERSION_INFO` | `true` | If enabled, the `/version` endpoint will provide the Docling package versions, otherwise it will return a forbidden 403 error. |
+|  | `DOCLING_SERVE_DEBUG_ERROR_DETAILS` | `false` | If enabled, raw internal exception detail is returned for debugging. When `false`, infrastructure-origin error details are sanitized in public HTTP/task surfaces. |
 |  | `DOCLING_SERVE_ENABLE_REMOTE_SERVICES` | `false` | Allow pipeline components making remote connections. For example, this is needed when using a vision-language model via APIs. |
 |  | `DOCLING_SERVE_ALLOW_EXTERNAL_PLUGINS` | `false` | Allow the selection of third-party plugins. |
 |  | `DOCLING_SERVE_ALLOW_CUSTOM_VLM_CONFIG` | `false` | Allow users to specify a fully custom VLM pipeline configuration (`vlm_pipeline_custom_config`). When `false`, only presets are accepted. |

--- a/docs/plans/implement-error-response-sanitation.md
+++ b/docs/plans/implement-error-response-sanitation.md
@@ -1,0 +1,77 @@
+# Error Detail Sanitization With Debug Override
+
+## Summary
+- Add a canonical server flag, `DOCLING_SERVE_DEBUG_ERROR_DETAILS`, default `false`.
+- When the flag is `false`, suppress infrastructure exception details from public responses and callbacks, while keeping raw exceptions in logs.
+- When the flag is `true`, allow current exception detail to propagate for debugging.
+- Preserve intentionally public, explicit error messages that are already safe: policy validation, timeouts, result-not-found, backpressure, dispatcher unavailable, watchdog/orphan-state messages.
+
+## Implementation Changes
+- Add `debug_error_details: bool = False` to `docling_serve` settings and document `DOCLING_SERVE_DEBUG_ERROR_DETAILS` in [docs/configuration.md](docs/configuration.md).
+- Thread that flag from `docling-serve` into jobkit orchestrator configs in [docling_serve/orchestrator_factory.py](docling_serve/orchestrator_factory.py).
+- Extend jobkit config objects so both Ray and RQ paths receive the flag programmatically. `RayOrchestratorConfig` should carry it directly; `RQOrchestratorConfig` should gain the same field.
+- Add one shared jobkit helper module for public error shaping and use it from the exception-ingestion points.
+
+## Helper Responsibilities
+- `build_public_task_error(exc, debug_enabled) -> str`
+  - Used when an infrastructure exception is being copied into `Task.error_message` or a pub/sub task update.
+  - In debug mode, return `str(exc) or exc.__class__.__name__`.
+  - In non-debug mode, return one stable generic message such as `Internal processing error.`
+  - Never log; formatting only.
+
+- `build_public_error_item(exc, debug_enabled) -> ErrorItem`
+  - Used when an infrastructure exception is being turned into a document-scoped `ErrorItem`.
+  - In debug mode, preserve current behavior: exception class name in `module_name`, exception text in `error_message`.
+  - In non-debug mode, emit a safe synthetic item, for example `module_name="internal_error"` and `error_message="Internal document processing error."`
+  - Always produce a schema-valid `ErrorItem`; no `None` fields.
+
+- `render_public_error_list(errors, debug_enabled) -> str | None`
+  - Used only for callback/reporting string fields that currently do `str(exportable_document.errors)`.
+  - Accepts already-public `ErrorItem`s and renders them into a readable string without Python repr output.
+  - In non-debug mode, join the public `error_message` values only.
+  - In debug mode, may include `module_name` prefixes, but still as deliberate formatting rather than raw list repr.
+  - Returns `None` when the list is empty.
+
+- `build_public_http_detail(exc, debug_enabled, fallback_message: str) -> str`
+  - Used in `docling-serve` service-layer `HTTPException(detail=...)` sites that currently use `str(exc)`.
+  - In debug mode, return `str(exc) or fallback_message`.
+  - In non-debug mode, return the supplied safe fallback.
+  - Keeps sanitization policy for HTTP error bodies separate from orchestration/task models.
+
+## Ingestion Points
+- Use `build_public_error_item(...)` at Ray slice failure construction in `serve_deployment.py`.
+- Use `build_public_task_error(...)` at:
+  - Ray coordinator failure terminalization/publication in `serve_deployment.py`
+  - Ray dispatcher failure terminalization/publication in `dispatcher.py`
+  - RQ worker failure publication in `rq/worker.py`
+- Use `render_public_error_list(...)` in jobkit callback/reporting code:
+  - `FailedDocsItem.error` in `convert/results.py` and `convert/chunking.py`
+  - `DocumentCompletedItem.error` in `convert/results.py` and `convert/chunking.py`
+- Use `build_public_http_detail(...)` in `docling-serve` for raw `str(exc)` HTTP detail sites such as readiness and progress validation.
+- Leave explicit safe messages authored directly in app code unchanged.
+
+## Public Interfaces
+- New env var: `DOCLING_SERVE_DEBUG_ERROR_DETAILS=false`.
+- New internal config field on jobkit Ray/RQ configs: `debug_error_details: bool`.
+- No response schema changes. Existing fields remain, but their values become sanitized by default.
+- No origin-tagging/data-model extension in v1. This pass fixes known infrastructure injection points instead of retrofitting provenance onto all `ErrorItem`s.
+
+## Test Plan
+- `docling-serve` unit tests:
+  - readiness returns generic 503 detail by default and raw detail when debug flag is on
+  - progress callback validation returns generic 400 detail by default and raw detail when debug flag is on
+  - async status/websocket responses expose generic `error_message` by default and raw text when debug flag is on
+  - `DispatcherUnavailableError` and other explicit safe messages remain unchanged
+- `docling-jobkit` unit tests:
+  - Ray slice failure builds sanitized `ErrorItem` by default and raw `module_name`/message when debug flag is on
+  - Ray dispatcher/coordinator failure publication stores sanitized `error_message` by default and raw text when debug flag is on
+  - RQ worker failure publication does the same
+  - callback error rendering no longer emits Python list/dataclass reprs
+- Cross-path behavior tests:
+  - library-generated document errors still pass through unchanged with debug off
+  - infrastructure-origin failures surface as generic messages in convert/chunk result errors, async task status, websocket updates, and callback payloads
+
+## Assumptions
+- This pass addresses the audited, known exception-stringification paths and does not add heuristic post-hoc scrubbing of arbitrary `ConversionResult.errors`.
+- Raw exception detail remains available in server logs regardless of the flag.
+- `DOCLING_SERVE_DEBUG_ERROR_DETAILS` is the canonical deployment control; standalone jobkit callers can set the config field directly if needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@ pytorch-triton-rocm = [
   { index = "pytorch-rocm", marker = "sys_platform == 'linux'" },
 ]
 
-docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "cau/ray-page-slicing" }
+docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "cau/error-sanitation" }
 
 # docling = { git = "https://github.com/docling-project/docling/", rev = "main" }
 # docling-jobkit = { path = "../docling-jobkit", editable = true }

--- a/tests/test_env_parsing.py
+++ b/tests/test_env_parsing.py
@@ -51,3 +51,12 @@ def test_default_values():
 
     assert settings.allowed_vlm_presets is None
     assert settings.custom_vlm_presets == {}
+    assert settings.debug_error_details is False
+
+
+def test_debug_error_details_from_env(monkeypatch):
+    monkeypatch.setenv("DOCLING_SERVE_DEBUG_ERROR_DETAILS", "true")
+
+    settings = DoclingServeSettings()
+
+    assert settings.debug_error_details is True

--- a/tests/test_health_probes.py
+++ b/tests/test_health_probes.py
@@ -66,7 +66,9 @@ async def test_readyz_alias(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_readyz_for_ray_runs_deep_connection_check(client: AsyncClient):
     original_engine = docling_serve_settings.eng_kind
+    original_debug = docling_serve_settings.debug_error_details
     docling_serve_settings.eng_kind = AsyncEngine.RAY
+    docling_serve_settings.debug_error_details = False
     try:
         orchestrator = MagicMock()
         orchestrator.check_connection = AsyncMock(
@@ -79,10 +81,35 @@ async def test_readyz_for_ray_runs_deep_connection_check(client: AsyncClient):
             response = await client.get("/readyz")
     finally:
         docling_serve_settings.eng_kind = original_engine
+        docling_serve_settings.debug_error_details = original_debug
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Readiness check failed"
+    orchestrator.check_connection.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_readyz_exposes_raw_error_in_debug_mode(client: AsyncClient):
+    original_engine = docling_serve_settings.eng_kind
+    original_debug = docling_serve_settings.debug_error_details
+    docling_serve_settings.eng_kind = AsyncEngine.RAY
+    docling_serve_settings.debug_error_details = True
+    try:
+        orchestrator = MagicMock()
+        orchestrator.check_connection = AsyncMock(
+            side_effect=RuntimeError("Ray dispatcher unavailable")
+        )
+
+        with patch(
+            "docling_serve.app.get_async_orchestrator", return_value=orchestrator
+        ):
+            response = await client.get("/readyz")
+    finally:
+        docling_serve_settings.eng_kind = original_engine
+        docling_serve_settings.debug_error_details = original_debug
 
     assert response.status_code == 503
     assert response.json()["detail"] == "Ray dispatcher unavailable"
-    orchestrator.check_connection.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
This change hardens `docling-serve`'s public error surfaces so infrastructure exception details are no longer exposed by default.

A new deployment flag, `DOCLING_SERVE_DEBUG_ERROR_DETAILS`, controls whether raw exception text is returned:
- `false` (default): public HTTP error details are sanitized
- `true`: current raw exception detail is preserved for debugging

## Why
Several service-layer error paths were returning `str(exc)` directly in public responses. That can leak backend/runtime internals such as Ray exception text, wrapper errors, and operational details that are useful in logs but should not be part of the default API surface.

This change keeps raw detail available in debug mode while making the default production behavior safer and more stable.

## What changed
- Added `debug_error_details: bool = False` to `DoclingServeSettings`
- Documented `DOCLING_SERVE_DEBUG_ERROR_DETAILS` in `docs/configuration.md`
- Added a small helper for rendering public HTTP error details consistently
- Sanitized the main audited HTTP error paths:
  - readiness failures
  - internal progress callback validation failures
  - Ray `DispatcherUnavailableError` 503 responses
- Threaded the debug flag into Ray and RQ orchestrator config creation so downstream jobkit sanitization can use the same deployment control

## Behavior
With debug disabled:
- readiness returns a generic `Readiness check failed`
- invalid internal progress callback payloads return `Invalid progress payload.`
- Ray dispatcher-unavailable responses return `Ray dispatcher is unavailable.`

With debug enabled:
- those same responses surface the underlying exception detail again

## Scope
This PR changes error value rendering only. It does not change response schemas or endpoint contracts.
