### PR TITLE
feat: expose OCR text-layer skip option

### DIFF
--- a/docling_serve/gradio_ui.py
+++ b/docling_serve/gradio_ui.py
@@ -354,6 +354,7 @@ def process_url(
     pipeline,
     ocr,
     force_ocr,
+    ocr_skip_text_layer_pages,
     ocr_engine,
     ocr_lang,
     pdf_backend,
@@ -376,6 +377,7 @@ def process_url(
             "pipeline": pipeline,
             "ocr": ocr,
             "force_ocr": force_ocr,
+            "ocr_skip_text_layer_pages": ocr_skip_text_layer_pages,
             "ocr_engine": ocr_engine,
             "ocr_lang": _to_list_of_strings(ocr_lang),
             "pdf_backend": pdf_backend,
@@ -436,6 +438,7 @@ def process_file(
     pipeline,
     ocr,
     force_ocr,
+    ocr_skip_text_layer_pages,
     ocr_engine,
     ocr_lang,
     pdf_backend,
@@ -464,6 +467,7 @@ def process_file(
             "pipeline": pipeline,
             "ocr": ocr,
             "force_ocr": force_ocr,
+            "ocr_skip_text_layer_pages": ocr_skip_text_layer_pages,
             "ocr_engine": ocr_engine,
             "ocr_lang": _to_list_of_strings(ocr_lang),
             "pdf_backend": pdf_backend,
@@ -694,6 +698,9 @@ with gr.Blocks(
             with gr.Column(scale=1, min_width=200):
                 ocr = gr.Checkbox(label="Enable OCR", value=True)
                 force_ocr = gr.Checkbox(label="Force OCR", value=False)
+                ocr_skip_text_layer_pages = gr.Checkbox(
+                    label="Skip text-layer pages", value=False
+                )
             with gr.Column(scale=1):
                 engines_list = [
                     ("Auto", "auto"),
@@ -831,6 +838,7 @@ with gr.Blocks(
             pipeline,
             ocr,
             force_ocr,
+            ocr_skip_text_layer_pages,
             ocr_engine,
             ocr_lang,
             pdf_backend,
@@ -919,6 +927,7 @@ with gr.Blocks(
             pipeline,
             ocr,
             force_ocr,
+            ocr_skip_text_layer_pages,
             ocr_engine,
             ocr_lang,
             pdf_backend,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,7 @@ On top of the source of file (see below), both endpoints support the same parame
 | `image_export_mode` | ImageRefMode | Image export mode for the document (in case of JSON, Markdown or HTML). Allowed values: `placeholder`, `embedded`, `referenced`. Optional, defaults to Embedded. |
 | `do_ocr` | bool | If enabled, the bitmap content will be processed using OCR. Boolean. Optional, defaults to true |
 | `force_ocr` | bool | If enabled, replace existing text with OCR-generated text over content. Boolean. Optional, defaults to false. |
+| `ocr_skip_text_layer_pages` | bool | If enabled, skip OCR on pages with enough native text cells. Boolean. Optional, defaults to false. |
 | `ocr_engine` | str | DEPRECATED: Use ocr_preset instead. The OCR engine to use. String.  |
 | `ocr_lang` | List[str] or NoneType | List of languages used by the OCR engine. Note that each OCR engine has different values for the language names. String or list of strings. Optional, defaults to empty. |
 | `ocr_preset` | str | Preset ID for OCR engine. |
@@ -202,6 +203,7 @@ Simple payload example:
     "image_export_mode": "placeholder",
     "do_ocr": true,
     "force_ocr": false,
+    "ocr_skip_text_layer_pages": false,
     "ocr_engine": "easyocr",
     "ocr_lang": ["en"],
     "pdf_backend": "dlparse_v2",
@@ -239,6 +241,7 @@ curl -X 'POST' \
     "image_export_mode": "placeholder",
     "do_ocr": true,
     "force_ocr": false,
+    "ocr_skip_text_layer_pages": false,
     "ocr_engine": "easyocr",
     "ocr_lang": [
       "fr",
@@ -368,6 +371,7 @@ parameters = {
 "image_export_mode": "placeholder",
 "do_ocr": True,
 "force_ocr": False,
+"ocr_skip_text_layer_pages": False,
 "ocr_engine": "easyocr",
 "ocr_lang": ["en"],
 "pdf_backend": "dlparse_v2",

--- a/scripts/update_doc_usage.py
+++ b/scripts/update_doc_usage.py
@@ -16,6 +16,7 @@ VARIABLE_WORDS: list[str] = [
     "vlm",
     "vlm_pipeline_model_api",
     "ocr_engines_enum",
+    "ocr_skip_text_layer_pages",
     "easyocr",
     "dlparse_v4",
     "docling_parse",


### PR DESCRIPTION
## Summary

This exposes the OCR text-layer skip option in docling-serve once the lower layers land:

- adds a Gradio checkbox for `ocr_skip_text_layer_pages`
- sends the option in URL and file conversion requests
- updates usage docs and the docs formatter variable list

This is the serve-side follow-up for:

- docling-project/docling#3464
- docling-project/docling#3465
- docling-project/docling-jobkit#149

## Dependency

This PR depends on the Docling schema and jobkit mapping from the linked PRs. It is intentionally small so the service surface is ready once those lower-layer changes are available in the dependency stack.

## Validation

- `uv run python -m py_compile docling_serve/gradio_ui.py scripts/update_doc_usage.py`
- `uv run pytest tests/test_service_policy.py::test_convert_options_shim_points_to_shared_type`
- `git diff --check`

Note: `uv run ruff check docling_serve/gradio_ui.py scripts/update_doc_usage.py` currently reports a pre-existing `UP045` diagnostic at `docling_serve/gradio_ui.py:212`, unrelated to this change.