### PR TITLE
feat: expose docs metadata in callbacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = ">=3.10"
 dependencies = [
     "docling[remote-serving]>=2.88.0,<3.0.0",
     "docling-core>=2.45.0",
-    "docling-jobkit[kfp,rq,ray,vlm]>=1.19.1,<2.0.0",
+    "docling-jobkit[kfp,rq,ray,vlm]>=1.20.0,<2.0.0",
     "fastapi[standard]<0.137.0",
     "httpx~=0.28",
     "pydantic~=2.10",
@@ -81,7 +81,7 @@ dev = [
     "mypy~=1.11",
     "pre-commit-uv~=4.1",
     "pypdf>=6.0.0",
-    "pytest~=8.3",
+    "pytest>=8.3,<10.0.0",
     "pytest-asyncio~=0.24",
     "pytest-check~=2.4",
     "python-semantic-release~=7.32",


### PR DESCRIPTION
Expose metadata in callbacks and update dependencies

Docling

```
Updated docling v2.94.0 -> v2.95.0
Updated docling-jobkit v1.19.1 -> v1.20.0
Updated docling-slim v2.94.0 -> v2.95.0
```

Others

```
Updated aiohappyeyeballs v2.6.1 -> v2.6.2
Updated boto3 v1.43.11 -> v1.43.12
Updated botocore v1.43.11 -> v1.43.12
Updated huggingface-hub v1.15.0 -> v1.16.0
Updated pypdf v6.11.0 -> v6.12.0
Updated rich-toolkit v0.19.9 -> v0.19.10
Updated transformers v5.8.1 -> v5.9.0
```

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
