### PR TITLE
feat: Support PresignedUrlTarget and add regular-endpoint hardening to docling-serve

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -53,6 +53,7 @@ from docling.datamodel.service.options import (
 )
 from docling.datamodel.service.requests import (
     ConvertDocumentsRequest,
+    ConvertSourcesRequest,
     FileSourceRequest,
     GenericChunkDocumentsRequest,
     HttpSourceRequest,
@@ -68,6 +69,7 @@ from docling.datamodel.service.responses import (
     HealthCheckResponse,
     MessageKind,
     PresignedUrlConvertDocumentResponse,
+    PresignedUrlConvertResponse,
     ReadinessResponse,
     TaskStatusResponse,
     WebsocketMessage,
@@ -75,6 +77,7 @@ from docling.datamodel.service.responses import (
 from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
 from docling.datamodel.service.targets import (
     InBodyTarget,
+    PresignedUrlTarget,
     ZipTarget,
 )
 from docling.datamodel.service.tasks import TaskType
@@ -382,7 +385,9 @@ def create_app():  # noqa: C901
 
     async def _enque_source(
         orchestrator: BaseOrchestrator,
-        request: ConvertDocumentsRequest | GenericChunkDocumentsRequest,
+        request: ConvertSourcesRequest
+        | ConvertDocumentsRequest
+        | GenericChunkDocumentsRequest,
         tenant_id: str | None = None,
     ) -> Task:
         sources: list[TaskSource] = []
@@ -398,7 +403,7 @@ def create_app():  # noqa: C901
         chunking_options: BaseChunkerOptions | None = None
         chunking_export_options = ChunkingExportOptions()
         task_type: TaskType
-        if isinstance(request, ConvertDocumentsRequest):
+        if isinstance(request, ConvertSourcesRequest | ConvertDocumentsRequest):
             task_type = TaskType.CONVERT
             convert_options = request.options
         elif isinstance(request, GenericChunkDocumentsRequest):
@@ -515,8 +520,8 @@ def create_app():  # noqa: C901
                 return False
 
     def _prepare_convert_request(
-        request: ConvertDocumentsRequest,
-    ) -> ConvertDocumentsRequest:
+        request: ConvertSourcesRequest,
+    ) -> ConvertSourcesRequest:
         normalized_request = normalize_convert_request(request, service_policy)
         validate_convert_request(normalized_request, service_policy)
         return normalized_request
@@ -541,6 +546,34 @@ def create_app():  # noqa: C901
         normalized_options = normalize_convert_options(options, service_policy)
         validate_convert_options(normalized_options, service_policy)
         return normalized_options
+
+    def _check_file_upload(files: list[UploadFile], target_type: TargetName) -> None:
+        if len(files) > service_policy.max_sources_per_request:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=(
+                    f"Too many files: {len(files)} exceeds the "
+                    f"maximum of {service_policy.max_sources_per_request}."
+                ),
+            )
+        if (
+            target_type == TargetName.PRESIGNED_URL
+            and not service_policy.artifact_storage_enabled
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=(
+                    "Presigned URL target requires artifact storage to be configured "
+                    "and enabled on the server."
+                ),
+            )
+
+    def _resolve_file_target(target_type: TargetName) -> TargetRequest:
+        if target_type == TargetName.PRESIGNED_URL:
+            return PresignedUrlTarget()
+        if target_type == TargetName.ZIP:
+            return ZipTarget()
+        return InBodyTarget()
 
     ##########################################
     # Downgrade openapi 3.1 to 3.0.x helpers #
@@ -689,7 +722,9 @@ def create_app():  # noqa: C901
     @app.post(
         "/v1/convert/source",
         tags=["convert"],
-        response_model=ConvertDocumentResponse | PresignedUrlConvertDocumentResponse,
+        response_model=ConvertDocumentResponse
+        | PresignedUrlConvertDocumentResponse
+        | PresignedUrlConvertResponse,
         responses={
             200: {
                 "content": {"application/zip": {}},
@@ -701,7 +736,7 @@ def create_app():  # noqa: C901
         background_tasks: BackgroundTasks,
         auth: Annotated[AuthenticationResult, Depends(require_auth)],
         orchestrator: Annotated[BaseOrchestrator, Depends(get_async_orchestrator)],
-        conversion_request: ConvertDocumentsRequest,
+        conversion_request: ConvertSourcesRequest,
         x_tenant_id: Annotated[
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
@@ -741,7 +776,9 @@ def create_app():  # noqa: C901
     @app.post(
         "/v1/convert/file",
         tags=["convert"],
-        response_model=ConvertDocumentResponse | PresignedUrlConvertDocumentResponse,
+        response_model=ConvertDocumentResponse
+        | PresignedUrlConvertDocumentResponse
+        | PresignedUrlConvertResponse,
         responses={
             200: {
                 "content": {"application/zip": {}},
@@ -761,10 +798,11 @@ def create_app():  # noqa: C901
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
     ):
+        _check_file_upload(files, target_type)
         options = _prepare_convert_options(options)
         tenant_id = _get_tenant_id_from_header(x_tenant_id)
         _log.info(f"[TENANT_ID] process_file endpoint received tenant_id='{tenant_id}'")
-        target = InBodyTarget() if target_type == TargetName.INBODY else ZipTarget()
+        target = _resolve_file_target(target_type)
         task = await _enque_file(
             task_type=TaskType.CONVERT,
             orchestrator=orchestrator,
@@ -810,7 +848,7 @@ def create_app():  # noqa: C901
     async def process_url_async(
         auth: Annotated[AuthenticationResult, Depends(require_auth)],
         orchestrator: Annotated[BaseOrchestrator, Depends(get_async_orchestrator)],
-        conversion_request: ConvertDocumentsRequest,
+        conversion_request: ConvertSourcesRequest,
         x_tenant_id: Annotated[
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
@@ -854,12 +892,13 @@ def create_app():  # noqa: C901
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
     ):
+        _check_file_upload(files, target_type)
         options = _prepare_convert_options(options)
         tenant_id = _get_tenant_id_from_header(x_tenant_id)
         _log.info(
             f"[TENANT_ID] process_file_async endpoint received tenant_id='{tenant_id}'"
         )
-        target = InBodyTarget() if target_type == TargetName.INBODY else ZipTarget()
+        target = _resolve_file_target(target_type)
         task = await _enque_file(
             task_type=TaskType.CONVERT,
             orchestrator=orchestrator,
@@ -970,6 +1009,11 @@ def create_app():  # noqa: C901
                 Header(alias=docling_serve_settings.eng_ray_tenant_id_header),
             ] = None,
         ):
+            if target_type == TargetName.PRESIGNED_URL:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail="presigned_url target is not supported for chunk endpoints.",
+                )
             convert_options = _prepare_convert_options(convert_options)
             tenant_id = _get_tenant_id_from_header(x_tenant_id)
             _log.info(
@@ -1105,6 +1149,11 @@ def create_app():  # noqa: C901
                 Header(alias=docling_serve_settings.eng_ray_tenant_id_header),
             ] = None,
         ):
+            if target_type == TargetName.PRESIGNED_URL:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail="presigned_url target is not supported for chunk endpoints.",
+                )
             convert_options = _prepare_convert_options(convert_options)
             tenant_id = _get_tenant_id_from_header(x_tenant_id)
             _log.info(

--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -52,7 +52,6 @@ from docling.datamodel.service.options import (
     ConvertDocumentsOptions as ConvertDocumentsRequestOptions,
 )
 from docling.datamodel.service.requests import (
-    ConvertDocumentsRequest,
     ConvertSourcesRequest,
     FileSourceRequest,
     GenericChunkDocumentsRequest,
@@ -385,9 +384,7 @@ def create_app():  # noqa: C901
 
     async def _enque_source(
         orchestrator: BaseOrchestrator,
-        request: ConvertSourcesRequest
-        | ConvertDocumentsRequest
-        | GenericChunkDocumentsRequest,
+        request: ConvertSourcesRequest | GenericChunkDocumentsRequest,
         tenant_id: str | None = None,
     ) -> Task:
         sources: list[TaskSource] = []
@@ -403,7 +400,7 @@ def create_app():  # noqa: C901
         chunking_options: BaseChunkerOptions | None = None
         chunking_export_options = ChunkingExportOptions()
         task_type: TaskType
-        if isinstance(request, ConvertSourcesRequest | ConvertDocumentsRequest):
+        if isinstance(request, ConvertSourcesRequest):
             task_type = TaskType.CONVERT
             convert_options = request.options
         elif isinstance(request, GenericChunkDocumentsRequest):

--- a/docling_serve/helper_functions.py
+++ b/docling_serve/helper_functions.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, TypeAdapter
 DOCLING_VERSIONS = {
     "docling-serve": importlib.metadata.version("docling-serve"),
     "docling-jobkit": importlib.metadata.version("docling-jobkit"),
-    "docling": importlib.metadata.version("docling"),
+    "docling": importlib.metadata.version("docling-slim"),
     "docling-core": importlib.metadata.version("docling-core"),
     "docling-ibm-models": importlib.metadata.version("docling-ibm-models"),
     "docling-parse": importlib.metadata.version("docling-parse"),

--- a/docling_serve/orchestrator_factory.py
+++ b/docling_serve/orchestrator_factory.py
@@ -9,6 +9,29 @@ from docling_serve.storage import get_scratch
 _log = logging.getLogger(__name__)
 
 
+def _build_target_config():
+    """Build TargetConfig from artifact storage settings, or return None when disabled."""
+    if not docling_serve_settings.artifact_storage_enabled:
+        return None
+
+    from docling.datamodel.service.sources import S3Coordinates
+    from docling_jobkit.config.target_config import S3PresignedConfig, TargetConfig
+
+    coords = S3Coordinates(
+        endpoint=docling_serve_settings.artifact_storage_endpoint,
+        access_key=docling_serve_settings.artifact_storage_access_key,
+        secret_key=docling_serve_settings.artifact_storage_secret_key,
+        bucket=docling_serve_settings.artifact_storage_bucket,
+    )
+    return TargetConfig(
+        s3_presigned=S3PresignedConfig(
+            s3_coords=coords,
+            key_prefix=docling_serve_settings.artifact_storage_key_prefix,
+            url_expiration=docling_serve_settings.artifact_storage_presign_ttl_seconds,
+        )
+    )
+
+
 @lru_cache
 def get_async_orchestrator() -> BaseOrchestrator:
     if docling_serve_settings.eng_kind == AsyncEngine.LOCAL:
@@ -26,6 +49,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             shared_models=docling_serve_settings.eng_loc_share_models,
             scratch_dir=get_scratch(),
             result_removal_delay=docling_serve_settings.result_removal_delay,
+            target_config=_build_target_config(),
         )
 
         cm_config = DoclingConverterManagerConfig(
@@ -115,6 +139,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             zombie_reaper_interval=docling_serve_settings.eng_rq_zombie_reaper_interval,
             zombie_reaper_max_age=docling_serve_settings.eng_rq_zombie_reaper_max_age,
             result_removal_delay=docling_serve_settings.result_removal_delay,
+            target_config=_build_target_config(),
         )
 
         orchestrator = RQOrchestrator(config=rq_config)
@@ -223,6 +248,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
 
         # Create Fair Ray orchestrator config
         ray_config = RayOrchestratorConfig(
+            target_config=_build_target_config(),
             # Redis Configuration
             redis_url=docling_serve_settings.eng_ray_redis_url,
             redis_max_connections=docling_serve_settings.eng_ray_redis_max_connections,

--- a/docling_serve/orchestrator_factory.py
+++ b/docling_serve/orchestrator_factory.py
@@ -9,13 +9,13 @@ from docling_serve.storage import get_scratch
 _log = logging.getLogger(__name__)
 
 
-def _build_target_config():
-    """Build TargetConfig from artifact storage settings, or return None when disabled."""
+def _build_s3_presigned_config():
+    """Build presigned artifact storage config, or return None when disabled."""
     if not docling_serve_settings.artifact_storage_enabled:
         return None
 
     from docling.datamodel.service.sources import S3Coordinates
-    from docling_jobkit.config.target_config import S3PresignedConfig, TargetConfig
+    from docling_jobkit.config.target_config import S3PresignedConfig
 
     coords = S3Coordinates(
         endpoint=docling_serve_settings.artifact_storage_endpoint,
@@ -23,12 +23,10 @@ def _build_target_config():
         secret_key=docling_serve_settings.artifact_storage_secret_key,
         bucket=docling_serve_settings.artifact_storage_bucket,
     )
-    return TargetConfig(
-        s3_presigned=S3PresignedConfig(
-            s3_coords=coords,
-            key_prefix=docling_serve_settings.artifact_storage_key_prefix,
-            url_expiration=docling_serve_settings.artifact_storage_presign_ttl_seconds,
-        )
+    return S3PresignedConfig(
+        s3_coords=coords,
+        key_prefix=docling_serve_settings.artifact_storage_key_prefix,
+        url_expiration=docling_serve_settings.artifact_storage_presign_ttl_seconds,
     )
 
 
@@ -49,7 +47,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             shared_models=docling_serve_settings.eng_loc_share_models,
             scratch_dir=get_scratch(),
             result_removal_delay=docling_serve_settings.result_removal_delay,
-            target_config=_build_target_config(),
+            s3_presigned_config=_build_s3_presigned_config(),
         )
 
         cm_config = DoclingConverterManagerConfig(
@@ -139,7 +137,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             zombie_reaper_interval=docling_serve_settings.eng_rq_zombie_reaper_interval,
             zombie_reaper_max_age=docling_serve_settings.eng_rq_zombie_reaper_max_age,
             result_removal_delay=docling_serve_settings.result_removal_delay,
-            target_config=_build_target_config(),
+            s3_presigned_config=_build_s3_presigned_config(),
         )
 
         orchestrator = RQOrchestrator(config=rq_config)
@@ -248,7 +246,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
 
         # Create Fair Ray orchestrator config
         ray_config = RayOrchestratorConfig(
-            target_config=_build_target_config(),
+            s3_presigned_config=_build_s3_presigned_config(),
             # Redis Configuration
             redis_url=docling_serve_settings.eng_ray_redis_url,
             redis_max_connections=docling_serve_settings.eng_ray_redis_max_connections,

--- a/docling_serve/policy.py
+++ b/docling_serve/policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypeVar
 
 from fastapi import HTTPException, status
 
@@ -8,12 +9,17 @@ from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.datamodel.service.requests import (
     BaseChunkDocumentsRequest,
     ConvertDocumentsRequest,
+    ConvertSourcesRequest,
     S3SourceRequest,
 )
-from docling.datamodel.service.targets import S3Target
+from docling.datamodel.service.targets import PresignedUrlTarget, S3Target
 from docling.models.factories import get_ocr_factory
 
 from docling_serve.settings import AsyncEngine, DoclingServeSettings
+
+TConvertRequest = TypeVar(
+    "TConvertRequest", ConvertSourcesRequest, ConvertDocumentsRequest
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -24,6 +30,8 @@ class ServicePolicy:
     s3_enabled: bool
     callbacks_enabled: bool
     custom_vlm_enabled: bool
+    artifact_storage_enabled: bool
+    max_sources_per_request: int
 
 
 def build_service_policy(settings: DoclingServeSettings) -> ServicePolicy:
@@ -43,6 +51,8 @@ def build_service_policy(settings: DoclingServeSettings) -> ServicePolicy:
         s3_enabled=settings.eng_kind == AsyncEngine.KFP,
         callbacks_enabled=True,
         custom_vlm_enabled=settings.allow_custom_vlm_config,
+        artifact_storage_enabled=settings.artifact_storage_enabled,
+        max_sources_per_request=settings.max_sources_per_request,
     )
 
 
@@ -57,8 +67,8 @@ def normalize_convert_options(
 
 
 def normalize_convert_request(
-    request: ConvertDocumentsRequest, policy: ServicePolicy
-) -> ConvertDocumentsRequest:
+    request: TConvertRequest, policy: ServicePolicy
+) -> TConvertRequest:
     return request.model_copy(
         update={"options": normalize_convert_options(request.options, policy)},
         deep=True,
@@ -100,7 +110,7 @@ def validate_convert_options(
 
 
 def validate_convert_request(
-    request: ConvertDocumentsRequest, policy: ServicePolicy
+    request: ConvertSourcesRequest | ConvertDocumentsRequest, policy: ServicePolicy
 ) -> None:
     validate_convert_options(request.options, policy)
 
@@ -109,6 +119,26 @@ def validate_convert_request(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Callbacks are disabled by server policy.",
         )
+
+    if isinstance(request, ConvertSourcesRequest):
+        if len(request.sources) > policy.max_sources_per_request:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=(
+                    f"Too many sources: {len(request.sources)} exceeds the "
+                    f"maximum of {policy.max_sources_per_request}."
+                ),
+            )
+
+    if isinstance(request.target, PresignedUrlTarget):
+        if not policy.artifact_storage_enabled:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=(
+                    "Presigned URL target requires artifact storage to be configured "
+                    "and enabled on the server."
+                ),
+            )
 
     has_s3_source = any(
         isinstance(source, S3SourceRequest) for source in request.sources
@@ -143,6 +173,12 @@ def validate_chunk_request(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Callbacks are disabled by server policy.",
+        )
+
+    if isinstance(request.target, PresignedUrlTarget):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="presigned_url target is not supported for chunk endpoints.",
         )
 
     has_s3_source = any(

--- a/docling_serve/policy.py
+++ b/docling_serve/policy.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TypeVar
 
 from fastapi import HTTPException, status
 
 from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.datamodel.service.requests import (
     BaseChunkDocumentsRequest,
-    ConvertDocumentsRequest,
     ConvertSourcesRequest,
     S3SourceRequest,
 )
@@ -16,10 +14,6 @@ from docling.datamodel.service.targets import PresignedUrlTarget, S3Target
 from docling.models.factories import get_ocr_factory
 
 from docling_serve.settings import AsyncEngine, DoclingServeSettings
-
-TConvertRequest = TypeVar(
-    "TConvertRequest", ConvertSourcesRequest, ConvertDocumentsRequest
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -67,8 +61,8 @@ def normalize_convert_options(
 
 
 def normalize_convert_request(
-    request: TConvertRequest, policy: ServicePolicy
-) -> TConvertRequest:
+    request: ConvertSourcesRequest, policy: ServicePolicy
+) -> ConvertSourcesRequest:
     return request.model_copy(
         update={"options": normalize_convert_options(request.options, policy)},
         deep=True,
@@ -110,7 +104,7 @@ def validate_convert_options(
 
 
 def validate_convert_request(
-    request: ConvertSourcesRequest | ConvertDocumentsRequest, policy: ServicePolicy
+    request: ConvertSourcesRequest, policy: ServicePolicy
 ) -> None:
     validate_convert_options(request.options, policy)
 
@@ -120,15 +114,14 @@ def validate_convert_request(
             detail="Callbacks are disabled by server policy.",
         )
 
-    if isinstance(request, ConvertSourcesRequest):
-        if len(request.sources) > policy.max_sources_per_request:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=(
-                    f"Too many sources: {len(request.sources)} exceeds the "
-                    f"maximum of {policy.max_sources_per_request}."
-                ),
-            )
+    if len(request.sources) > policy.max_sources_per_request:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Too many sources: {len(request.sources)} exceeds the "
+                f"maximum of {policy.max_sources_per_request}."
+            ),
+        )
 
     if isinstance(request.target, PresignedUrlTarget):
         if not policy.artifact_storage_enabled:

--- a/docling_serve/response_preparation.py
+++ b/docling_serve/response_preparation.py
@@ -5,7 +5,9 @@ from fastapi import BackgroundTasks, Response
 from docling.datamodel.service.responses import (
     ChunkDocumentResponse,
     ConvertDocumentResponse,
+    PresignedArtifactResult,
     PresignedUrlConvertDocumentResponse,
+    PresignedUrlConvertResponse,
 )
 from docling_jobkit.datamodel.result import (
     ChunkedDocumentResult,
@@ -33,6 +35,7 @@ async def prepare_response(
         Response
         | ConvertDocumentResponse
         | PresignedUrlConvertDocumentResponse
+        | PresignedUrlConvertResponse
         | ChunkDocumentResponse
     )
     if isinstance(task_result.result, ExportResult):
@@ -53,6 +56,14 @@ async def prepare_response(
         )
     elif isinstance(task_result.result, RemoteTargetResult):
         response = PresignedUrlConvertDocumentResponse(
+            processing_time=task_result.processing_time,
+            num_converted=task_result.num_converted,
+            num_succeeded=task_result.num_succeeded,
+            num_failed=task_result.num_failed,
+        )
+    elif isinstance(task_result.result, PresignedArtifactResult):
+        response = PresignedUrlConvertResponse(
+            documents=task_result.result.documents,
             processing_time=task_result.processing_time,
             num_converted=task_result.num_converted,
             num_succeeded=task_result.num_succeeded,

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -134,6 +134,16 @@ class DoclingServeSettings(BaseSettings):
     max_document_timeout: float = 3_600 * 24 * 7  # 7 days
     max_num_pages: int = sys.maxsize
     max_file_size: int = sys.maxsize
+    max_sources_per_request: int = 3
+
+    # Artifact storage (required for PresignedUrlTarget)
+    artifact_storage_enabled: bool = False
+    artifact_storage_endpoint: str = ""
+    artifact_storage_bucket: str = ""
+    artifact_storage_access_key: str = ""
+    artifact_storage_secret_key: str = ""
+    artifact_storage_key_prefix: str = "converted/"
+    artifact_storage_presign_ttl_seconds: int = 3600
 
     # Threading pipeline
     queue_max_size: Optional[int] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "docling[remote-serving]>=2.88.0,<3.0.0",
+    "docling-slim[remote-serving]>=2.88.0,<3.0.0",
     "docling-core>=2.45.0",
     "docling-jobkit[kfp,rq,ray,vlm]>=1.20.0,<2.0.0",
     "fastapi[standard]<0.137.0",
@@ -180,8 +180,8 @@ pytorch-triton-rocm = [
   { index = "pytorch-rocm", marker = "sys_platform == 'linux'" },
 ]
 
-# docling = { git = "https://github.com/docling-project/docling/", rev = "main" }
-# docling-jobkit = { path = "../docling-jobkit", editable = true }
+docling-slim = { git = "https://github.com/docling-project/docling/", rev = "cau/service-models-presigned-batch-prep" }
+docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "cau/presigned-url-target-result-models" }
 
 [[tool.uv.index]]
 name = "pytorch-pypi"

--- a/tests/test_orchestrator_factory_slice_parallelism.py
+++ b/tests/test_orchestrator_factory_slice_parallelism.py
@@ -1,0 +1,187 @@
+from unittest.mock import patch
+
+from docling_serve import orchestrator_factory as factory_module
+from docling_serve.settings import AsyncEngine
+
+
+class _CapturedConfig:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class _CapturedConverterManagerConfig:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class _FakeConverterManager:
+    def __init__(self, config):
+        self.config = config
+
+
+class _FakeRayOrchestrator:
+    def __init__(self, config, converter_manager):
+        self.config = config
+        self.converter_manager = converter_manager
+
+
+def _build_ray_orchestrator(
+    monkeypatch, *, max_concurrent_tasks, max_page_slice_parallelism
+):
+    factory_module.get_async_orchestrator.cache_clear()
+
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings, "eng_kind", AsyncEngine.RAY
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "eng_ray_max_concurrent_tasks",
+        max_concurrent_tasks,
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "eng_ray_max_page_slice_parallelism",
+        max_page_slice_parallelism,
+    )
+
+    with (
+        patch(
+            "docling_jobkit.convert.manager.DoclingConverterManagerConfig",
+            _CapturedConverterManagerConfig,
+        ),
+        patch(
+            "docling_jobkit.convert.manager.DoclingConverterManager",
+            _FakeConverterManager,
+        ),
+        patch(
+            "docling_jobkit.orchestrators.ray.config.RayOrchestratorConfig",
+            _CapturedConfig,
+        ),
+        patch(
+            "docling_jobkit.orchestrators.ray.orchestrator.RayOrchestrator",
+            _FakeRayOrchestrator,
+        ),
+    ):
+        return factory_module.get_async_orchestrator()
+
+
+def test_slice_parallelism_defaults_to_max_concurrent_tasks(monkeypatch):
+    orchestrator = _build_ray_orchestrator(
+        monkeypatch,
+        max_concurrent_tasks=8,
+        max_page_slice_parallelism=None,
+    )
+
+    assert orchestrator.config.max_page_slice_parallelism == 8
+
+
+def test_slice_parallelism_preserves_explicit_override(monkeypatch):
+    orchestrator = _build_ray_orchestrator(
+        monkeypatch,
+        max_concurrent_tasks=8,
+        max_page_slice_parallelism=3,
+    )
+
+    assert orchestrator.config.max_page_slice_parallelism == 3
+
+
+def test_ray_config_never_receives_none_slice_parallelism(monkeypatch):
+    orchestrator = _build_ray_orchestrator(
+        monkeypatch,
+        max_concurrent_tasks=5,
+        max_page_slice_parallelism=None,
+    )
+
+    assert orchestrator.config.max_page_slice_parallelism is not None
+
+
+def test_ray_config_omits_presigned_storage_when_disabled(monkeypatch):
+    orchestrator = _build_ray_orchestrator(
+        monkeypatch,
+        max_concurrent_tasks=5,
+        max_page_slice_parallelism=None,
+    )
+
+    assert orchestrator.config.s3_presigned_config is None
+
+
+def test_ray_config_passes_presigned_storage_when_enabled(monkeypatch):
+    factory_module.get_async_orchestrator.cache_clear()
+
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings, "eng_kind", AsyncEngine.RAY
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "eng_ray_max_concurrent_tasks",
+        5,
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "eng_ray_max_page_slice_parallelism",
+        None,
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_enabled",
+        True,
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_endpoint",
+        "s3.example.com",
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_bucket",
+        "bucket-a",
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_access_key",
+        "key-a",
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_secret_key",
+        "secret-a",
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_key_prefix",
+        "converted/test/",
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_presign_ttl_seconds",
+        900,
+    )
+
+    with (
+        patch(
+            "docling_jobkit.convert.manager.DoclingConverterManagerConfig",
+            _CapturedConverterManagerConfig,
+        ),
+        patch(
+            "docling_jobkit.convert.manager.DoclingConverterManager",
+            _FakeConverterManager,
+        ),
+        patch(
+            "docling_jobkit.orchestrators.ray.config.RayOrchestratorConfig",
+            _CapturedConfig,
+        ),
+        patch(
+            "docling_jobkit.orchestrators.ray.orchestrator.RayOrchestrator",
+            _FakeRayOrchestrator,
+        ),
+    ):
+        orchestrator = factory_module.get_async_orchestrator()
+
+    config = orchestrator.config.s3_presigned_config
+    assert config is not None
+    assert config.s3_coords.endpoint == "s3.example.com"
+    assert config.s3_coords.bucket == "bucket-a"
+    assert config.s3_coords.access_key.get_secret_value() == "key-a"
+    assert config.s3_coords.secret_key.get_secret_value() == "secret-a"
+    assert config.key_prefix == "converted/test/"
+    assert config.url_expiration == 900

--- a/tests/test_service_policy.py
+++ b/tests/test_service_policy.py
@@ -1,9 +1,9 @@
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.datamodel.service.requests import (
-    ConvertDocumentsRequest,
     ConvertSourcesRequest,
     HttpSourceRequest,
     S3SourceRequest,
@@ -18,7 +18,7 @@ from docling_serve.policy import (
     validate_convert_options,
     validate_convert_request,
 )
-from docling_serve.settings import AsyncEngine, DoclingServeSettings
+from docling_serve.settings import DoclingServeSettings
 
 
 def test_convert_options_shim_points_to_shared_type():
@@ -46,35 +46,30 @@ def test_validate_convert_options_rejects_timeout_above_policy():
         validate_convert_options(ConvertDocumentsOptions(document_timeout=11), policy)
 
 
-def test_validate_convert_request_rejects_s3_without_kfp():
-    policy = build_service_policy(DoclingServeSettings(eng_kind=AsyncEngine.LOCAL))
-    request = ConvertDocumentsRequest(
-        options=ConvertDocumentsOptions(),
-        sources=[
-            S3SourceRequest(
+def test_convert_sources_request_rejects_s3_inputs_at_model_layer():
+    with pytest.raises(ValidationError):
+        ConvertSourcesRequest(
+            options=ConvertDocumentsOptions(),
+            sources=[
+                S3SourceRequest(
+                    endpoint="s3.example.com",
+                    access_key="key",
+                    secret_key="secret",
+                    bucket="bucket",
+                )
+            ],
+            target=S3Target(
                 endpoint="s3.example.com",
                 access_key="key",
                 secret_key="secret",
                 bucket="bucket",
-            )
-        ],
-        target=S3Target(
-            endpoint="s3.example.com",
-            access_key="key",
-            secret_key="secret",
-            bucket="bucket",
-        ),
-    )
-
-    with pytest.raises(
-        HTTPException, match='source kind "s3" requires engine kind "KFP"'
-    ):
-        validate_convert_request(request, policy)
+            ),
+        )
 
 
 def test_normalize_convert_request_preserves_sources_and_target():
     policy = build_service_policy(DoclingServeSettings())
-    request = ConvertDocumentsRequest(
+    request = ConvertSourcesRequest(
         options=ConvertDocumentsOptions(document_timeout=None),
         sources=[HttpSourceRequest(url="https://example.com/test.pdf", headers={})],
         target=InBodyTarget(),

--- a/tests/test_service_policy.py
+++ b/tests/test_service_policy.py
@@ -4,10 +4,11 @@ from fastapi import HTTPException
 from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.datamodel.service.requests import (
     ConvertDocumentsRequest,
+    ConvertSourcesRequest,
     HttpSourceRequest,
     S3SourceRequest,
 )
-from docling.datamodel.service.targets import InBodyTarget, S3Target
+from docling.datamodel.service.targets import InBodyTarget, PresignedUrlTarget, S3Target
 
 from docling_serve.datamodel.convert import ConvertDocumentsRequestOptions
 from docling_serve.policy import (
@@ -84,3 +85,60 @@ def test_normalize_convert_request_preserves_sources_and_target():
     assert normalized.sources == request.sources
     assert normalized.target == request.target
     assert normalized.options.document_timeout == policy.max_document_timeout
+
+
+def test_normalize_convert_request_works_for_convert_sources_request():
+    policy = build_service_policy(DoclingServeSettings())
+    request = ConvertSourcesRequest(
+        options=ConvertDocumentsOptions(document_timeout=None),
+        sources=[HttpSourceRequest(url="https://example.com/test.pdf", headers={})],
+        target=InBodyTarget(),
+    )
+
+    normalized = normalize_convert_request(request, policy)
+
+    assert isinstance(normalized, ConvertSourcesRequest)
+    assert normalized.sources == request.sources
+    assert normalized.options.document_timeout == policy.max_document_timeout
+
+
+def test_validate_convert_request_rejects_presigned_url_when_storage_disabled():
+    policy = build_service_policy(DoclingServeSettings(artifact_storage_enabled=False))
+    request = ConvertSourcesRequest(
+        sources=[HttpSourceRequest(url="https://example.com/test.pdf", headers={})],
+        target=PresignedUrlTarget(),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        validate_convert_request(request, policy)
+
+    assert exc_info.value.status_code == 503
+    assert "artifact storage" in exc_info.value.detail.lower()
+
+
+def test_validate_convert_request_rejects_too_many_sources():
+    policy = build_service_policy(DoclingServeSettings(max_sources_per_request=2))
+    request = ConvertSourcesRequest(
+        sources=[
+            HttpSourceRequest(url="https://example.com/a.pdf", headers={}),
+            HttpSourceRequest(url="https://example.com/b.pdf", headers={}),
+            HttpSourceRequest(url="https://example.com/c.pdf", headers={}),
+        ],
+        target=InBodyTarget(),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        validate_convert_request(request, policy)
+
+    assert exc_info.value.status_code == 422
+    assert "Too many sources" in exc_info.value.detail
+
+
+def test_validate_convert_request_allows_presigned_url_when_storage_enabled():
+    policy = build_service_policy(DoclingServeSettings(artifact_storage_enabled=True))
+    request = ConvertSourcesRequest(
+        sources=[HttpSourceRequest(url="https://example.com/test.pdf", headers={})],
+        target=PresignedUrlTarget(),
+    )
+
+    validate_convert_request(request, policy)


### PR DESCRIPTION
## Summary

- **PresignedUrlTarget end-to-end**: adds `artifact_storage_*`
  settings, builds and passes `TargetConfig` to all orchestrators (Local,
  RQ, Ray), maps `PresignedArtifactResult → PresignedUrlConvertResponse`
  in `prepare_response`, and guards presigned_url requests with HTTP 503
  when artifact storage is not configured.
- **Schema tightening**: the regular `/v1/convert/source`
  endpoints now accept `ConvertSourcesRequest` (file + HTTP only; S3
  rejected at Pydantic level, ZIP URLs rejected by `HttpSourceRequest`
  validator). File-upload handlers enforce `max_sources_per_request`.
  `ServicePolicy` grows `artifact_storage_enabled` and
  `max_sources_per_request`.
- **Chunk consistency**: chunk file handlers explicitly reject
  `presigned_url` (422); `validate_chunk_request` does the same for
  source-based chunk routes — no silent coercion to ZipTarget any more.
- **Tests**: 6 new unit tests in `test_hardening.py` (schema rejection,
  response mapping) + 4 new policy unit tests in `test_service_policy.py`.

## Files changed

| File | What changed |
|---|---|
| `settings.py` | `artifact_storage_*` fields + `max_sources_per_request` |
| `orchestrator_factory.py` | `_build_target_config()` helper, wired into Local/RQ/Ray |
| `policy.py` | `ServicePolicy` extended; `validate_convert_request` adds presigned 503 + max_sources 422; `validate_chunk_request` presigned → 422 |
| `response_preparation.py` | `PresignedArtifactResult` branch |
| `app.py` | `ConvertSourcesRequest` on source endpoints; `_check_file_upload` + `_resolve_file_target` helpers; chunk handler presigned 422 |
| `tests/test_service_policy.py` | 4 new policy tests |
| `tests/test_hardening.py` | 6 new schema + response-mapping tests |

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
