### PR TITLE
feat: add `/v1/convert/source/batch` endpoint

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -121,23 +121,6 @@ except (ImportError, Exception):
     pass
 
 
-# Set up custom logging as we'll be intermixes with FastAPI/Uvicorn's logging
-class ColoredLogFormatter(logging.Formatter):
-    COLOR_CODES = {
-        logging.DEBUG: "\033[94m",  # Blue
-        logging.INFO: "\033[92m",  # Green
-        logging.WARNING: "\033[93m",  # Yellow
-        logging.ERROR: "\033[91m",  # Red
-        logging.CRITICAL: "\033[95m",  # Magenta
-    }
-    RESET_CODE = "\033[0m"
-
-    def format(self, record):
-        color = self.COLOR_CODES.get(record.levelno, "")
-        record.levelname = f"{color}{record.levelname}{self.RESET_CODE}"
-        return super().format(record)
-
-
 # Configure logging based on settings
 # This will be called early, but can be reconfigured in __main__.py
 log_level = (

--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -52,10 +52,10 @@ from docling.datamodel.service.options import (
     ConvertDocumentsOptions as ConvertDocumentsRequestOptions,
 )
 from docling.datamodel.service.requests import (
+    BatchConvertSourcesRequest,
     ConvertSourcesRequest,
     FileSourceRequest,
     GenericChunkDocumentsRequest,
-    HttpSourceRequest,
     S3SourceRequest,
     TargetName,
     TargetRequest,
@@ -99,8 +99,10 @@ from docling_serve.otel_instrumentation import (
 )
 from docling_serve.policy import (
     build_service_policy,
+    normalize_batch_convert_request,
     normalize_convert_options,
     normalize_convert_request,
+    validate_batch_convert_request,
     validate_chunk_request,
     validate_convert_options,
     validate_convert_request,
@@ -384,14 +386,18 @@ def create_app():  # noqa: C901
 
     async def _enque_source(
         orchestrator: BaseOrchestrator,
-        request: ConvertSourcesRequest | GenericChunkDocumentsRequest,
+        request: (
+            BatchConvertSourcesRequest
+            | ConvertSourcesRequest
+            | GenericChunkDocumentsRequest
+        ),
         tenant_id: str | None = None,
     ) -> Task:
         sources: list[TaskSource] = []
         for s in request.sources:
             if isinstance(s, FileSourceRequest):
                 sources.append(FileSource.model_validate(s))
-            elif isinstance(s, HttpSourceRequest):
+            elif isinstance(s, HttpSource):
                 sources.append(HttpSource.model_validate(s))
             elif isinstance(s, S3SourceRequest):
                 sources.append(S3Coordinates.model_validate(s))
@@ -400,7 +406,7 @@ def create_app():  # noqa: C901
         chunking_options: BaseChunkerOptions | None = None
         chunking_export_options = ChunkingExportOptions()
         task_type: TaskType
-        if isinstance(request, ConvertSourcesRequest):
+        if isinstance(request, BatchConvertSourcesRequest | ConvertSourcesRequest):
             task_type = TaskType.CONVERT
             convert_options = request.options
         elif isinstance(request, GenericChunkDocumentsRequest):
@@ -415,9 +421,9 @@ def create_app():  # noqa: C901
 
         # Prepare metadata with tenant_id BEFORE enqueueing
         # This is critical because ray orchestrator reads tenant_id during enqueue()
-        metadata = {}
+        task_metadata: dict[str, str] = {}
         if tenant_id:
-            metadata["tenant_id"] = tenant_id
+            task_metadata["tenant_id"] = tenant_id
             _log.info(
                 f"[TENANT_ID] Preparing to enqueue with tenant_id='{tenant_id}' in metadata"
             )
@@ -432,7 +438,7 @@ def create_app():  # noqa: C901
             chunking_export_options=chunking_export_options,
             target=request.target,
             callbacks=request.callbacks,
-            metadata=metadata,
+            metadata=task_metadata,
         )
 
         _log.info(
@@ -521,6 +527,13 @@ def create_app():  # noqa: C901
     ) -> ConvertSourcesRequest:
         normalized_request = normalize_convert_request(request, service_policy)
         validate_convert_request(normalized_request, service_policy)
+        return normalized_request
+
+    def _prepare_batch_convert_request(
+        request: BatchConvertSourcesRequest,
+    ) -> BatchConvertSourcesRequest:
+        normalized_request = normalize_batch_convert_request(request, service_policy)
+        validate_batch_convert_request(normalized_request, service_policy)
         return normalized_request
 
     def _prepare_chunk_request(
@@ -857,6 +870,41 @@ def create_app():  # noqa: C901
         )
         task = await _enque_source(
             orchestrator=orchestrator, request=conversion_request, tenant_id=tenant_id
+        )
+        task_queue_position = await orchestrator.get_queue_position(
+            task_id=task.task_id
+        )
+        return TaskStatusResponse(
+            task_id=task.task_id,
+            task_type=task.task_type,
+            task_status=task.task_status,
+            task_position=task_queue_position,
+            task_meta=task.processing_meta,
+            error_message=getattr(task, "error_message", None),
+        )
+
+    @app.post(
+        "/v1/convert/source/batch",
+        tags=["convert"],
+        response_model=TaskStatusResponse,
+    )
+    async def process_source_batch(
+        auth: Annotated[AuthenticationResult, Depends(require_auth)],
+        orchestrator: Annotated[BaseOrchestrator, Depends(get_async_orchestrator)],
+        conversion_request: BatchConvertSourcesRequest,
+        x_tenant_id: Annotated[
+            str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
+        ] = None,
+    ):
+        conversion_request = _prepare_batch_convert_request(conversion_request)
+        tenant_id = _get_tenant_id_from_header(x_tenant_id)
+        _log.info(
+            f"[TENANT_ID] process_source_batch endpoint received tenant_id='{tenant_id}'"
+        )
+        task = await _enque_source(
+            orchestrator=orchestrator,
+            request=conversion_request,
+            tenant_id=tenant_id,
         )
         task_queue_position = await orchestrator.get_queue_position(
             task_id=task.task_id
@@ -1328,6 +1376,7 @@ def create_app():  # noqa: C901
         tags=["tasks"],
         response_model=ConvertDocumentResponse
         | PresignedUrlConvertDocumentResponse
+        | PresignedUrlConvertResponse
         | ChunkDocumentResponse,
         responses={
             200: {

--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -571,7 +571,7 @@ def create_app():  # noqa: C901
             and not service_policy.artifact_storage_enabled
         ):
             raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=(
                     "Presigned URL target requires artifact storage to be configured "
                     "and enabled on the server."

--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -99,9 +99,8 @@ from docling_serve.otel_instrumentation import (
 )
 from docling_serve.policy import (
     build_service_policy,
-    normalize_batch_convert_request,
     normalize_convert_options,
-    normalize_convert_request,
+    normalize_request,
     validate_batch_convert_request,
     validate_chunk_request,
     validate_convert_options,
@@ -525,14 +524,14 @@ def create_app():  # noqa: C901
     def _prepare_convert_request(
         request: ConvertSourcesRequest,
     ) -> ConvertSourcesRequest:
-        normalized_request = normalize_convert_request(request, service_policy)
+        normalized_request = normalize_request(request, service_policy)
         validate_convert_request(normalized_request, service_policy)
         return normalized_request
 
     def _prepare_batch_convert_request(
         request: BatchConvertSourcesRequest,
     ) -> BatchConvertSourcesRequest:
-        normalized_request = normalize_batch_convert_request(request, service_policy)
+        normalized_request = normalize_request(request, service_policy)
         validate_batch_convert_request(normalized_request, service_policy)
         return normalized_request
 
@@ -880,7 +879,7 @@ def create_app():  # noqa: C901
             task_status=task.task_status,
             task_position=task_queue_position,
             task_meta=task.processing_meta,
-            error_message=getattr(task, "error_message", None),
+            error_message=task.error_message,
         )
 
     @app.post(
@@ -915,7 +914,7 @@ def create_app():  # noqa: C901
             task_status=task.task_status,
             task_position=task_queue_position,
             task_meta=task.processing_meta,
-            error_message=getattr(task, "error_message", None),
+            error_message=task.error_message,
         )
 
     # Convert a document from file(s) using the async api
@@ -964,7 +963,7 @@ def create_app():  # noqa: C901
             task_status=task.task_status,
             task_position=task_queue_position,
             task_meta=task.processing_meta,
-            error_message=getattr(task, "error_message", None),
+            error_message=task.error_message,
         )
 
     # Chunking endpoints
@@ -1007,7 +1006,7 @@ def create_app():  # noqa: C901
                 task_status=task.task_status,
                 task_position=task_queue_position,
                 task_meta=task.processing_meta,
-                error_message=getattr(task, "error_message", None),
+                error_message=task.error_message,
             )
 
         @app.post(
@@ -1087,7 +1086,7 @@ def create_app():  # noqa: C901
                 task_status=task.task_status,
                 task_position=task_queue_position,
                 task_meta=task.processing_meta,
-                error_message=getattr(task, "error_message", None),
+                error_message=task.error_message,
             )
 
         @app.post(
@@ -1269,7 +1268,7 @@ def create_app():  # noqa: C901
             task_status=task.task_status,
             task_position=task_queue_position,
             task_meta=task.processing_meta,
-            error_message=getattr(task, "error_message", None),
+            error_message=task.error_message,
         )
 
     # Task status websocket
@@ -1323,7 +1322,7 @@ def create_app():  # noqa: C901
                 task_status=task.task_status,
                 task_position=task_queue_position,
                 task_meta=task.processing_meta,
-                error_message=getattr(task, "error_message", None),
+                error_message=task.error_message,
             )
             await websocket.send_text(
                 WebsocketMessage(
@@ -1340,7 +1339,7 @@ def create_app():  # noqa: C901
                     task_status=task.task_status,
                     task_position=task_queue_position,
                     task_meta=task.processing_meta,
-                    error_message=getattr(task, "error_message", None),
+                    error_message=task.error_message,
                 )
                 await websocket.send_text(
                     WebsocketMessage(

--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -53,6 +53,7 @@ from docling.datamodel.service.options import (
 )
 from docling.datamodel.service.requests import (
     ConvertDocumentsRequest,
+    ConvertSourcesRequest,
     FileSourceRequest,
     GenericChunkDocumentsRequest,
     HttpSourceRequest,
@@ -68,6 +69,7 @@ from docling.datamodel.service.responses import (
     HealthCheckResponse,
     MessageKind,
     PresignedUrlConvertDocumentResponse,
+    PresignedUrlConvertResponse,
     ReadinessResponse,
     TaskStatusResponse,
     WebsocketMessage,
@@ -75,6 +77,7 @@ from docling.datamodel.service.responses import (
 from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
 from docling.datamodel.service.targets import (
     InBodyTarget,
+    PresignedUrlTarget,
     ZipTarget,
 )
 from docling.datamodel.service.tasks import TaskType
@@ -382,7 +385,9 @@ def create_app():  # noqa: C901
 
     async def _enque_source(
         orchestrator: BaseOrchestrator,
-        request: ConvertDocumentsRequest | GenericChunkDocumentsRequest,
+        request: ConvertSourcesRequest
+        | ConvertDocumentsRequest
+        | GenericChunkDocumentsRequest,
         tenant_id: str | None = None,
     ) -> Task:
         sources: list[TaskSource] = []
@@ -398,7 +403,7 @@ def create_app():  # noqa: C901
         chunking_options: BaseChunkerOptions | None = None
         chunking_export_options = ChunkingExportOptions()
         task_type: TaskType
-        if isinstance(request, ConvertDocumentsRequest):
+        if isinstance(request, ConvertSourcesRequest | ConvertDocumentsRequest):
             task_type = TaskType.CONVERT
             convert_options = request.options
         elif isinstance(request, GenericChunkDocumentsRequest):
@@ -515,8 +520,8 @@ def create_app():  # noqa: C901
                 return False
 
     def _prepare_convert_request(
-        request: ConvertDocumentsRequest,
-    ) -> ConvertDocumentsRequest:
+        request: ConvertSourcesRequest,
+    ) -> ConvertSourcesRequest:
         normalized_request = normalize_convert_request(request, service_policy)
         validate_convert_request(normalized_request, service_policy)
         return normalized_request
@@ -541,6 +546,34 @@ def create_app():  # noqa: C901
         normalized_options = normalize_convert_options(options, service_policy)
         validate_convert_options(normalized_options, service_policy)
         return normalized_options
+
+    def _check_file_upload(files: list[UploadFile], target_type: TargetName) -> None:
+        if len(files) > service_policy.max_sources_per_request:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=(
+                    f"Too many files: {len(files)} exceeds the "
+                    f"maximum of {service_policy.max_sources_per_request}."
+                ),
+            )
+        if (
+            target_type == TargetName.PRESIGNED_URL
+            and not service_policy.artifact_storage_enabled
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=(
+                    "Presigned URL target requires artifact storage to be configured "
+                    "and enabled on the server."
+                ),
+            )
+
+    def _resolve_file_target(target_type: TargetName) -> TargetRequest:
+        if target_type == TargetName.PRESIGNED_URL:
+            return PresignedUrlTarget()
+        if target_type == TargetName.ZIP:
+            return ZipTarget()
+        return InBodyTarget()
 
     ##########################################
     # Downgrade openapi 3.1 to 3.0.x helpers #
@@ -689,7 +722,9 @@ def create_app():  # noqa: C901
     @app.post(
         "/v1/convert/source",
         tags=["convert"],
-        response_model=ConvertDocumentResponse | PresignedUrlConvertDocumentResponse,
+        response_model=ConvertDocumentResponse
+        | PresignedUrlConvertDocumentResponse
+        | PresignedUrlConvertResponse,
         responses={
             200: {
                 "content": {"application/zip": {}},
@@ -701,7 +736,7 @@ def create_app():  # noqa: C901
         background_tasks: BackgroundTasks,
         auth: Annotated[AuthenticationResult, Depends(require_auth)],
         orchestrator: Annotated[BaseOrchestrator, Depends(get_async_orchestrator)],
-        conversion_request: ConvertDocumentsRequest,
+        conversion_request: ConvertSourcesRequest,
         x_tenant_id: Annotated[
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
@@ -741,7 +776,9 @@ def create_app():  # noqa: C901
     @app.post(
         "/v1/convert/file",
         tags=["convert"],
-        response_model=ConvertDocumentResponse | PresignedUrlConvertDocumentResponse,
+        response_model=ConvertDocumentResponse
+        | PresignedUrlConvertDocumentResponse
+        | PresignedUrlConvertResponse,
         responses={
             200: {
                 "content": {"application/zip": {}},
@@ -761,10 +798,11 @@ def create_app():  # noqa: C901
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
     ):
+        _check_file_upload(files, target_type)
         options = _prepare_convert_options(options)
         tenant_id = _get_tenant_id_from_header(x_tenant_id)
         _log.info(f"[TENANT_ID] process_file endpoint received tenant_id='{tenant_id}'")
-        target = InBodyTarget() if target_type == TargetName.INBODY else ZipTarget()
+        target = _resolve_file_target(target_type)
         task = await _enque_file(
             task_type=TaskType.CONVERT,
             orchestrator=orchestrator,
@@ -810,7 +848,7 @@ def create_app():  # noqa: C901
     async def process_url_async(
         auth: Annotated[AuthenticationResult, Depends(require_auth)],
         orchestrator: Annotated[BaseOrchestrator, Depends(get_async_orchestrator)],
-        conversion_request: ConvertDocumentsRequest,
+        conversion_request: ConvertSourcesRequest,
         x_tenant_id: Annotated[
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
@@ -854,12 +892,13 @@ def create_app():  # noqa: C901
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
     ):
+        _check_file_upload(files, target_type)
         options = _prepare_convert_options(options)
         tenant_id = _get_tenant_id_from_header(x_tenant_id)
         _log.info(
             f"[TENANT_ID] process_file_async endpoint received tenant_id='{tenant_id}'"
         )
-        target = InBodyTarget() if target_type == TargetName.INBODY else ZipTarget()
+        target = _resolve_file_target(target_type)
         task = await _enque_file(
             task_type=TaskType.CONVERT,
             orchestrator=orchestrator,
@@ -970,6 +1009,11 @@ def create_app():  # noqa: C901
                 Header(alias=docling_serve_settings.eng_ray_tenant_id_header),
             ] = None,
         ):
+            if target_type == TargetName.PRESIGNED_URL:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail="presigned_url target is not supported for chunk endpoints.",
+                )
             convert_options = _prepare_convert_options(convert_options)
             tenant_id = _get_tenant_id_from_header(x_tenant_id)
             _log.info(
@@ -1105,6 +1149,11 @@ def create_app():  # noqa: C901
                 Header(alias=docling_serve_settings.eng_ray_tenant_id_header),
             ] = None,
         ):
+            if target_type == TargetName.PRESIGNED_URL:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail="presigned_url target is not supported for chunk endpoints.",
+                )
             convert_options = _prepare_convert_options(convert_options)
             tenant_id = _get_tenant_id_from_header(x_tenant_id)
             _log.info(

--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -52,7 +52,6 @@ from docling.datamodel.service.options import (
     ConvertDocumentsOptions as ConvertDocumentsRequestOptions,
 )
 from docling.datamodel.service.requests import (
-    ConvertDocumentsRequest,
     ConvertSourcesRequest,
     FileSourceRequest,
     GenericChunkDocumentsRequest,
@@ -385,9 +384,7 @@ def create_app():  # noqa: C901
 
     async def _enque_source(
         orchestrator: BaseOrchestrator,
-        request: ConvertSourcesRequest
-        | ConvertDocumentsRequest
-        | GenericChunkDocumentsRequest,
+        request: ConvertSourcesRequest | GenericChunkDocumentsRequest,
         tenant_id: str | None = None,
     ) -> Task:
         sources: list[TaskSource] = []
@@ -403,7 +400,7 @@ def create_app():  # noqa: C901
         chunking_options: BaseChunkerOptions | None = None
         chunking_export_options = ChunkingExportOptions()
         task_type: TaskType
-        if isinstance(request, ConvertSourcesRequest | ConvertDocumentsRequest):
+        if isinstance(request, ConvertSourcesRequest):
             task_type = TaskType.CONVERT
             convert_options = request.options
         elif isinstance(request, GenericChunkDocumentsRequest):

--- a/docling_serve/helper_functions.py
+++ b/docling_serve/helper_functions.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, TypeAdapter
 DOCLING_VERSIONS = {
     "docling-serve": importlib.metadata.version("docling-serve"),
     "docling-jobkit": importlib.metadata.version("docling-jobkit"),
-    "docling": importlib.metadata.version("docling"),
+    "docling": importlib.metadata.version("docling-slim"),
     "docling-core": importlib.metadata.version("docling-core"),
     "docling-ibm-models": importlib.metadata.version("docling-ibm-models"),
     "docling-parse": importlib.metadata.version("docling-parse"),

--- a/docling_serve/logging_config.py
+++ b/docling_serve/logging_config.py
@@ -21,6 +21,24 @@ _log_context: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar(
 )
 
 
+class ColoredLogFormatter(logging.Formatter):
+    """Colored formatter for text log output."""
+
+    COLOR_CODES = {
+        logging.DEBUG: "\033[94m",  # Blue
+        logging.INFO: "\033[92m",  # Green
+        logging.WARNING: "\033[93m",  # Yellow
+        logging.ERROR: "\033[91m",  # Red
+        logging.CRITICAL: "\033[95m",  # Magenta
+    }
+    RESET_CODE = "\033[0m"
+
+    def format(self, record: logging.LogRecord) -> str:
+        color = self.COLOR_CODES.get(record.levelno, "")
+        record.levelname = f"{color}{record.levelname}{self.RESET_CODE}"
+        return super().format(record)
+
+
 def get_log_context() -> dict[str, Any]:
     """Get the current log context."""
     return _log_context.get()
@@ -178,9 +196,6 @@ def setup_logging(
     if log_format.lower() == "json":
         formatter = JSONLogFormatter()
     else:
-        # Use colored formatter for text logs
-        from docling_serve.app import ColoredLogFormatter
-
         formatter = ColoredLogFormatter(
             "%(levelname)s:\t%(asctime)s - %(name)s - %(message)s",
             datefmt="%H:%M:%S",

--- a/docling_serve/orchestrator_factory.py
+++ b/docling_serve/orchestrator_factory.py
@@ -9,6 +9,29 @@ from docling_serve.storage import get_scratch
 _log = logging.getLogger(__name__)
 
 
+def _build_target_config():
+    """Build TargetConfig from artifact storage settings, or return None when disabled."""
+    if not docling_serve_settings.artifact_storage_enabled:
+        return None
+
+    from docling.datamodel.service.sources import S3Coordinates
+    from docling_jobkit.config.target_config import S3PresignedConfig, TargetConfig
+
+    coords = S3Coordinates(
+        endpoint=docling_serve_settings.artifact_storage_endpoint,
+        access_key=docling_serve_settings.artifact_storage_access_key,
+        secret_key=docling_serve_settings.artifact_storage_secret_key,
+        bucket=docling_serve_settings.artifact_storage_bucket,
+    )
+    return TargetConfig(
+        s3_presigned=S3PresignedConfig(
+            s3_coords=coords,
+            key_prefix=docling_serve_settings.artifact_storage_key_prefix,
+            url_expiration=docling_serve_settings.artifact_storage_presign_ttl_seconds,
+        )
+    )
+
+
 @lru_cache
 def get_async_orchestrator() -> BaseOrchestrator:
     if docling_serve_settings.eng_kind == AsyncEngine.LOCAL:
@@ -26,6 +49,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             shared_models=docling_serve_settings.eng_loc_share_models,
             scratch_dir=get_scratch(),
             result_removal_delay=docling_serve_settings.result_removal_delay,
+            target_config=_build_target_config(),
         )
 
         cm_config = DoclingConverterManagerConfig(
@@ -115,6 +139,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             zombie_reaper_interval=docling_serve_settings.eng_rq_zombie_reaper_interval,
             zombie_reaper_max_age=docling_serve_settings.eng_rq_zombie_reaper_max_age,
             result_removal_delay=docling_serve_settings.result_removal_delay,
+            target_config=_build_target_config(),
         )
 
         orchestrator = RQOrchestrator(config=rq_config)
@@ -223,6 +248,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
 
         # Create Fair Ray orchestrator config
         ray_config = RayOrchestratorConfig(
+            target_config=_build_target_config(),
             # Redis Configuration
             redis_url=docling_serve_settings.eng_ray_redis_url,
             redis_max_connections=docling_serve_settings.eng_ray_redis_max_connections,

--- a/docling_serve/orchestrator_factory.py
+++ b/docling_serve/orchestrator_factory.py
@@ -10,7 +10,11 @@ _log = logging.getLogger(__name__)
 
 
 def _build_s3_presigned_config():
-    """Build presigned artifact storage config, or return None when disabled."""
+    """Build presigned artifact storage config, or return None when disabled.
+
+    The managed storage prefix and URL TTL are owned by docling-serve settings and
+    injected into jobkit here before any orchestrator is constructed.
+    """
     if not docling_serve_settings.artifact_storage_enabled:
         return None
 
@@ -23,10 +27,10 @@ def _build_s3_presigned_config():
         access_key=docling_serve_settings.artifact_storage_access_key,
         secret_key=docling_serve_settings.artifact_storage_secret_key,
         bucket=docling_serve_settings.artifact_storage_bucket,
+        key_prefix=docling_serve_settings.artifact_storage_key_prefix,
     )
     return S3PresignedConfig(
         s3_coords=coords,
-        key_prefix=docling_serve_settings.artifact_storage_key_prefix,
         url_expiration=docling_serve_settings.artifact_storage_presign_ttl_seconds,
     )
 

--- a/docling_serve/orchestrator_factory.py
+++ b/docling_serve/orchestrator_factory.py
@@ -19,6 +19,7 @@ def _build_s3_presigned_config():
 
     coords = S3Coordinates(
         endpoint=docling_serve_settings.artifact_storage_endpoint,
+        verify_ssl=docling_serve_settings.artifact_storage_verify_ssl,
         access_key=docling_serve_settings.artifact_storage_access_key,
         secret_key=docling_serve_settings.artifact_storage_secret_key,
         bucket=docling_serve_settings.artifact_storage_bucket,

--- a/docling_serve/orchestrator_factory.py
+++ b/docling_serve/orchestrator_factory.py
@@ -9,13 +9,13 @@ from docling_serve.storage import get_scratch
 _log = logging.getLogger(__name__)
 
 
-def _build_target_config():
-    """Build TargetConfig from artifact storage settings, or return None when disabled."""
+def _build_s3_presigned_config():
+    """Build presigned artifact storage config, or return None when disabled."""
     if not docling_serve_settings.artifact_storage_enabled:
         return None
 
     from docling.datamodel.service.sources import S3Coordinates
-    from docling_jobkit.config.target_config import S3PresignedConfig, TargetConfig
+    from docling_jobkit.config.target_config import S3PresignedConfig
 
     coords = S3Coordinates(
         endpoint=docling_serve_settings.artifact_storage_endpoint,
@@ -23,12 +23,10 @@ def _build_target_config():
         secret_key=docling_serve_settings.artifact_storage_secret_key,
         bucket=docling_serve_settings.artifact_storage_bucket,
     )
-    return TargetConfig(
-        s3_presigned=S3PresignedConfig(
-            s3_coords=coords,
-            key_prefix=docling_serve_settings.artifact_storage_key_prefix,
-            url_expiration=docling_serve_settings.artifact_storage_presign_ttl_seconds,
-        )
+    return S3PresignedConfig(
+        s3_coords=coords,
+        key_prefix=docling_serve_settings.artifact_storage_key_prefix,
+        url_expiration=docling_serve_settings.artifact_storage_presign_ttl_seconds,
     )
 
 
@@ -49,7 +47,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             shared_models=docling_serve_settings.eng_loc_share_models,
             scratch_dir=get_scratch(),
             result_removal_delay=docling_serve_settings.result_removal_delay,
-            target_config=_build_target_config(),
+            s3_presigned_config=_build_s3_presigned_config(),
         )
 
         cm_config = DoclingConverterManagerConfig(
@@ -139,7 +137,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             zombie_reaper_interval=docling_serve_settings.eng_rq_zombie_reaper_interval,
             zombie_reaper_max_age=docling_serve_settings.eng_rq_zombie_reaper_max_age,
             result_removal_delay=docling_serve_settings.result_removal_delay,
-            target_config=_build_target_config(),
+            s3_presigned_config=_build_s3_presigned_config(),
         )
 
         orchestrator = RQOrchestrator(config=rq_config)
@@ -248,7 +246,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
 
         # Create Fair Ray orchestrator config
         ray_config = RayOrchestratorConfig(
-            target_config=_build_target_config(),
+            s3_presigned_config=_build_s3_presigned_config(),
             # Redis Configuration
             redis_url=docling_serve_settings.eng_ray_redis_url,
             redis_max_connections=docling_serve_settings.eng_ray_redis_max_connections,

--- a/docling_serve/policy.py
+++ b/docling_serve/policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypeVar
 
 from fastapi import HTTPException, status
 
@@ -8,12 +9,17 @@ from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.datamodel.service.requests import (
     BaseChunkDocumentsRequest,
     ConvertDocumentsRequest,
+    ConvertSourcesRequest,
     S3SourceRequest,
 )
-from docling.datamodel.service.targets import S3Target
+from docling.datamodel.service.targets import PresignedUrlTarget, S3Target
 from docling.models.factories import get_ocr_factory
 
 from docling_serve.settings import AsyncEngine, DoclingServeSettings
+
+TConvertRequest = TypeVar(
+    "TConvertRequest", ConvertSourcesRequest, ConvertDocumentsRequest
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -24,6 +30,8 @@ class ServicePolicy:
     s3_enabled: bool
     callbacks_enabled: bool
     custom_vlm_enabled: bool
+    artifact_storage_enabled: bool
+    max_sources_per_request: int
 
 
 def build_service_policy(settings: DoclingServeSettings) -> ServicePolicy:
@@ -43,6 +51,8 @@ def build_service_policy(settings: DoclingServeSettings) -> ServicePolicy:
         s3_enabled=settings.eng_kind == AsyncEngine.KFP,
         callbacks_enabled=True,
         custom_vlm_enabled=settings.allow_custom_vlm_config,
+        artifact_storage_enabled=settings.artifact_storage_enabled,
+        max_sources_per_request=settings.max_sources_per_request,
     )
 
 
@@ -57,8 +67,8 @@ def normalize_convert_options(
 
 
 def normalize_convert_request(
-    request: ConvertDocumentsRequest, policy: ServicePolicy
-) -> ConvertDocumentsRequest:
+    request: TConvertRequest, policy: ServicePolicy
+) -> TConvertRequest:
     return request.model_copy(
         update={"options": normalize_convert_options(request.options, policy)},
         deep=True,
@@ -100,7 +110,7 @@ def validate_convert_options(
 
 
 def validate_convert_request(
-    request: ConvertDocumentsRequest, policy: ServicePolicy
+    request: ConvertSourcesRequest | ConvertDocumentsRequest, policy: ServicePolicy
 ) -> None:
     validate_convert_options(request.options, policy)
 
@@ -109,6 +119,26 @@ def validate_convert_request(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Callbacks are disabled by server policy.",
         )
+
+    if isinstance(request, ConvertSourcesRequest):
+        if len(request.sources) > policy.max_sources_per_request:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=(
+                    f"Too many sources: {len(request.sources)} exceeds the "
+                    f"maximum of {policy.max_sources_per_request}."
+                ),
+            )
+
+    if isinstance(request.target, PresignedUrlTarget):
+        if not policy.artifact_storage_enabled:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=(
+                    "Presigned URL target requires artifact storage to be configured "
+                    "and enabled on the server."
+                ),
+            )
 
     has_s3_source = any(
         isinstance(source, S3SourceRequest) for source in request.sources
@@ -143,6 +173,12 @@ def validate_chunk_request(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Callbacks are disabled by server policy.",
+        )
+
+    if isinstance(request.target, PresignedUrlTarget):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="presigned_url target is not supported for chunk endpoints.",
         )
 
     has_s3_source = any(

--- a/docling_serve/policy.py
+++ b/docling_serve/policy.py
@@ -202,6 +202,8 @@ def validate_batch_convert_request(
     )
     has_s3_target = isinstance(request.target, S3Target)
 
+    # Batch endpoint intentionally allows S3 sources on the Ray engine; only the
+    # S3 source -> S3 target pairing is enforced here.
     if has_s3_source and not has_s3_target:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,

--- a/docling_serve/policy.py
+++ b/docling_serve/policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypeVar
 
 from fastapi import HTTPException, status
 
@@ -15,6 +16,10 @@ from docling.datamodel.service.targets import PresignedUrlTarget, S3Target
 from docling.models.factories import get_ocr_factory
 
 from docling_serve.settings import AsyncEngine, DoclingServeSettings
+
+_ConvertRequestT = TypeVar(
+    "_ConvertRequestT", ConvertSourcesRequest, BatchConvertSourcesRequest
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,18 +66,9 @@ def normalize_convert_options(
     )
 
 
-def normalize_convert_request(
-    request: ConvertSourcesRequest, policy: ServicePolicy
-) -> ConvertSourcesRequest:
-    return request.model_copy(
-        update={"options": normalize_convert_options(request.options, policy)},
-        deep=True,
-    )
-
-
-def normalize_batch_convert_request(
-    request: BatchConvertSourcesRequest, policy: ServicePolicy
-) -> BatchConvertSourcesRequest:
+def normalize_request(
+    request: _ConvertRequestT, policy: ServicePolicy
+) -> _ConvertRequestT:
     return request.model_copy(
         update={"options": normalize_convert_options(request.options, policy)},
         deep=True,

--- a/docling_serve/policy.py
+++ b/docling_serve/policy.py
@@ -25,6 +25,7 @@ _ConvertRequestT = TypeVar(
 @dataclass(frozen=True, slots=True)
 class ServicePolicy:
     max_document_timeout: float
+    max_images_scale: float
     allow_external_plugins: bool
     allowed_ocr_presets: frozenset[str]
     s3_enabled: bool
@@ -32,6 +33,7 @@ class ServicePolicy:
     custom_vlm_enabled: bool
     artifact_storage_enabled: bool
     max_sources_per_request: int
+    allowed_image_export_modes: frozenset[str]
 
 
 def build_service_policy(settings: DoclingServeSettings) -> ServicePolicy:
@@ -44,8 +46,20 @@ def build_service_policy(settings: DoclingServeSettings) -> ServicePolicy:
     else:
         allowed_ocr_presets = set(settings.allowed_ocr_presets) & registered_ocr_presets
 
+    # Determine allowed image export modes
+    if settings.allowed_image_export_modes is None:
+        # All modes allowed by default
+        allowed_image_export_modes = {"placeholder", "referenced", "embedded"}
+    else:
+        # Validate that only known modes are specified
+        valid_modes = {"placeholder", "referenced", "embedded"}
+        allowed_image_export_modes = (
+            set(settings.allowed_image_export_modes) & valid_modes
+        )
+
     return ServicePolicy(
         max_document_timeout=settings.max_document_timeout,
+        max_images_scale=settings.max_images_scale,
         allow_external_plugins=settings.allow_external_plugins,
         allowed_ocr_presets=frozenset(allowed_ocr_presets),
         s3_enabled=settings.eng_kind == AsyncEngine.KFP,
@@ -53,6 +67,7 @@ def build_service_policy(settings: DoclingServeSettings) -> ServicePolicy:
         custom_vlm_enabled=settings.allow_custom_vlm_config,
         artifact_storage_enabled=settings.artifact_storage_enabled,
         max_sources_per_request=settings.max_sources_per_request,
+        allowed_image_export_modes=frozenset(allowed_image_export_modes),
     )
 
 
@@ -92,6 +107,14 @@ def validate_convert_options(
                     f"of {policy.max_document_timeout} seconds."
                 ),
             )
+    if options.images_scale > policy.max_images_scale:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                "images_scale exceeds the configured maximum "
+                f"of {policy.max_images_scale}."
+            ),
+        )
 
     if options.ocr_preset not in policy.allowed_ocr_presets:
         raise HTTPException(
@@ -99,6 +122,18 @@ def validate_convert_options(
             detail=(
                 f"ocr_preset '{options.ocr_preset}' is not allowed. "
                 f"Allowed values: {sorted(policy.allowed_ocr_presets)}."
+            ),
+        )
+
+    image_export_mode = getattr(
+        options.image_export_mode, "value", options.image_export_mode
+    )
+    if image_export_mode not in policy.allowed_image_export_modes:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"image_export_mode '{image_export_mode}' is not allowed. "
+                f"Allowed values: {sorted(policy.allowed_image_export_modes)}."
             ),
         )
 

--- a/docling_serve/policy.py
+++ b/docling_serve/policy.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException, status
 from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.datamodel.service.requests import (
     BaseChunkDocumentsRequest,
+    BatchConvertSourcesRequest,
     ConvertSourcesRequest,
     S3SourceRequest,
 )
@@ -63,6 +64,15 @@ def normalize_convert_options(
 def normalize_convert_request(
     request: ConvertSourcesRequest, policy: ServicePolicy
 ) -> ConvertSourcesRequest:
+    return request.model_copy(
+        update={"options": normalize_convert_options(request.options, policy)},
+        deep=True,
+    )
+
+
+def normalize_batch_convert_request(
+    request: BatchConvertSourcesRequest, policy: ServicePolicy
+) -> BatchConvertSourcesRequest:
     return request.model_copy(
         update={"options": normalize_convert_options(request.options, policy)},
         deep=True,
@@ -154,6 +164,48 @@ def validate_convert_request(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail='target kind "s3" requires source kind "s3".',
+        )
+
+
+def validate_batch_convert_request(
+    request: BatchConvertSourcesRequest, policy: ServicePolicy
+) -> None:
+    validate_convert_options(request.options, policy)
+
+    if request.callbacks and not policy.callbacks_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Callbacks are disabled by server policy.",
+        )
+
+    if len(request.sources) > policy.max_sources_per_request:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Too many sources: {len(request.sources)} exceeds the "
+                f"maximum of {policy.max_sources_per_request}."
+            ),
+        )
+
+    if isinstance(request.target, PresignedUrlTarget):
+        if not policy.artifact_storage_enabled:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=(
+                    "Presigned URL target requires artifact storage to be configured "
+                    "and enabled on the server."
+                ),
+            )
+
+    has_s3_source = any(
+        isinstance(source, S3SourceRequest) for source in request.sources
+    )
+    has_s3_target = isinstance(request.target, S3Target)
+
+    if has_s3_source and not has_s3_target:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="S3 sources require an S3 target on the batch endpoint.",
         )
 
 

--- a/docling_serve/policy.py
+++ b/docling_serve/policy.py
@@ -136,7 +136,7 @@ def validate_convert_request(
     if isinstance(request.target, PresignedUrlTarget):
         if not policy.artifact_storage_enabled:
             raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=(
                     "Presigned URL target requires artifact storage to be configured "
                     "and enabled on the server."
@@ -190,7 +190,7 @@ def validate_batch_convert_request(
     if isinstance(request.target, PresignedUrlTarget):
         if not policy.artifact_storage_enabled:
             raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=(
                     "Presigned URL target requires artifact storage to be configured "
                     "and enabled on the server."

--- a/docling_serve/policy.py
+++ b/docling_serve/policy.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TypeVar
 
 from fastapi import HTTPException, status
 
 from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.datamodel.service.requests import (
     BaseChunkDocumentsRequest,
-    ConvertDocumentsRequest,
     ConvertSourcesRequest,
     S3SourceRequest,
 )
@@ -16,10 +14,6 @@ from docling.datamodel.service.targets import PresignedUrlTarget, S3Target
 from docling.models.factories import get_ocr_factory
 
 from docling_serve.settings import AsyncEngine, DoclingServeSettings
-
-TConvertRequest = TypeVar(
-    "TConvertRequest", ConvertSourcesRequest, ConvertDocumentsRequest
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -67,8 +61,8 @@ def normalize_convert_options(
 
 
 def normalize_convert_request(
-    request: TConvertRequest, policy: ServicePolicy
-) -> TConvertRequest:
+    request: ConvertSourcesRequest, policy: ServicePolicy
+) -> ConvertSourcesRequest:
     return request.model_copy(
         update={"options": normalize_convert_options(request.options, policy)},
         deep=True,
@@ -110,7 +104,7 @@ def validate_convert_options(
 
 
 def validate_convert_request(
-    request: ConvertSourcesRequest | ConvertDocumentsRequest, policy: ServicePolicy
+    request: ConvertSourcesRequest, policy: ServicePolicy
 ) -> None:
     validate_convert_options(request.options, policy)
 
@@ -120,15 +114,14 @@ def validate_convert_request(
             detail="Callbacks are disabled by server policy.",
         )
 
-    if isinstance(request, ConvertSourcesRequest):
-        if len(request.sources) > policy.max_sources_per_request:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=(
-                    f"Too many sources: {len(request.sources)} exceeds the "
-                    f"maximum of {policy.max_sources_per_request}."
-                ),
-            )
+    if len(request.sources) > policy.max_sources_per_request:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Too many sources: {len(request.sources)} exceeds the "
+                f"maximum of {policy.max_sources_per_request}."
+            ),
+        )
 
     if isinstance(request.target, PresignedUrlTarget):
         if not policy.artifact_storage_enabled:

--- a/docling_serve/response_preparation.py
+++ b/docling_serve/response_preparation.py
@@ -1,18 +1,14 @@
-import logging
-
 from fastapi import BackgroundTasks, Response
 
 from docling.datamodel.service.responses import (
     ChunkDocumentResponse,
+    ChunkedDocumentResult,
     ConvertDocumentResponse,
+    DoclingTaskResult,
+    ExportResult,
     PresignedArtifactResult,
     PresignedUrlConvertDocumentResponse,
     PresignedUrlConvertResponse,
-)
-from docling_jobkit.datamodel.result import (
-    ChunkedDocumentResult,
-    DoclingTaskResult,
-    ExportResult,
     RemoteTargetResult,
     ZipArchiveResult,
 )
@@ -21,8 +17,6 @@ from docling_jobkit.orchestrators.base_orchestrator import (
 )
 
 from docling_serve.settings import docling_serve_settings
-
-_log = logging.getLogger(__name__)
 
 
 async def prepare_response(
@@ -40,7 +34,7 @@ async def prepare_response(
     )
     if isinstance(task_result.result, ExportResult):
         response = ConvertDocumentResponse(
-            document=task_result.result.content,
+            document=task_result.result.document,
             status=task_result.result.status,
             processing_time=task_result.processing_time,
             timings=task_result.result.timings,
@@ -59,6 +53,7 @@ async def prepare_response(
             processing_time=task_result.processing_time,
             num_converted=task_result.num_converted,
             num_succeeded=task_result.num_succeeded,
+            num_partial_success=task_result.num_partial_success,
             num_failed=task_result.num_failed,
         )
     elif isinstance(task_result.result, PresignedArtifactResult):
@@ -67,6 +62,7 @@ async def prepare_response(
             processing_time=task_result.processing_time,
             num_converted=task_result.num_converted,
             num_succeeded=task_result.num_succeeded,
+            num_partial_success=task_result.num_partial_success,
             num_failed=task_result.num_failed,
         )
     elif isinstance(task_result.result, ChunkedDocumentResult):

--- a/docling_serve/response_preparation.py
+++ b/docling_serve/response_preparation.py
@@ -5,7 +5,9 @@ from fastapi import BackgroundTasks, Response
 from docling.datamodel.service.responses import (
     ChunkDocumentResponse,
     ConvertDocumentResponse,
+    PresignedArtifactResult,
     PresignedUrlConvertDocumentResponse,
+    PresignedUrlConvertResponse,
 )
 from docling_jobkit.datamodel.result import (
     ChunkedDocumentResult,
@@ -33,6 +35,7 @@ async def prepare_response(
         Response
         | ConvertDocumentResponse
         | PresignedUrlConvertDocumentResponse
+        | PresignedUrlConvertResponse
         | ChunkDocumentResponse
     )
     if isinstance(task_result.result, ExportResult):
@@ -53,6 +56,14 @@ async def prepare_response(
         )
     elif isinstance(task_result.result, RemoteTargetResult):
         response = PresignedUrlConvertDocumentResponse(
+            processing_time=task_result.processing_time,
+            num_converted=task_result.num_converted,
+            num_succeeded=task_result.num_succeeded,
+            num_failed=task_result.num_failed,
+        )
+    elif isinstance(task_result.result, PresignedArtifactResult):
+        response = PresignedUrlConvertResponse(
+            documents=task_result.result.documents,
             processing_time=task_result.processing_time,
             num_converted=task_result.num_converted,
             num_succeeded=task_result.num_succeeded,

--- a/docling_serve/response_preparation.py
+++ b/docling_serve/response_preparation.py
@@ -53,7 +53,7 @@ async def prepare_response(
             processing_time=task_result.processing_time,
             num_converted=task_result.num_converted,
             num_succeeded=task_result.num_succeeded,
-            num_partial_success=task_result.num_partial_success,
+            num_partially_succeeded=task_result.num_partially_succeeded,
             num_failed=task_result.num_failed,
         )
     elif isinstance(task_result.result, PresignedArtifactResult):
@@ -62,7 +62,7 @@ async def prepare_response(
             processing_time=task_result.processing_time,
             num_converted=task_result.num_converted,
             num_succeeded=task_result.num_succeeded,
-            num_partial_success=task_result.num_partial_success,
+            num_partially_succeeded=task_result.num_partially_succeeded,
             num_failed=task_result.num_failed,
         )
     elif isinstance(task_result.result, ChunkedDocumentResult):

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -134,6 +134,16 @@ class DoclingServeSettings(BaseSettings):
     max_document_timeout: float = 3_600 * 24 * 7  # 7 days
     max_num_pages: int = sys.maxsize
     max_file_size: int = sys.maxsize
+    max_sources_per_request: int = 3
+
+    # Artifact storage (required for PresignedUrlTarget)
+    artifact_storage_enabled: bool = False
+    artifact_storage_endpoint: str = ""
+    artifact_storage_bucket: str = ""
+    artifact_storage_access_key: str = ""
+    artifact_storage_secret_key: str = ""
+    artifact_storage_key_prefix: str = "converted/"
+    artifact_storage_presign_ttl_seconds: int = 3600
 
     # Threading pipeline
     queue_max_size: Optional[int] = None

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -143,6 +143,10 @@ class DoclingServeSettings(BaseSettings):
     max_file_size: int = sys.maxsize
     max_sources_per_request: int = 3
 
+    # Image export policy
+    allowed_image_export_modes: Optional[list[str]] = None  # None = all modes allowed
+    max_images_scale: float = 2.0
+
     # Artifact storage (required for PresignedUrlTarget)
     artifact_storage_enabled: bool = False
     artifact_storage_endpoint: str = ""
@@ -429,6 +433,7 @@ class DoclingServeSettings(BaseSettings):
         "allowed_layout_presets",
         "allowed_ocr_presets",
         "allowed_ocr_kinds",
+        "allowed_image_export_modes",
         mode="before",
     )
     @classmethod

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -139,6 +139,7 @@ class DoclingServeSettings(BaseSettings):
     # Artifact storage (required for PresignedUrlTarget)
     artifact_storage_enabled: bool = False
     artifact_storage_endpoint: str = ""
+    artifact_storage_verify_ssl: bool = True
     artifact_storage_bucket: str = ""
     artifact_storage_access_key: str = ""
     artifact_storage_secret_key: str = ""

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,7 @@ THe following table describes the options to configure the Docling Serve app.
 | `--artifacts-path` | `DOCLING_SERVE_ARTIFACTS_PATH` | unset | If set to a valid directory, the model weights will be loaded from this path |
 |  | `DOCLING_SERVE_STATIC_PATH` | unset | If set to a valid directory, the static assets for the docs and UI will be loaded from this path |
 |  | `DOCLING_SERVE_SCRATCH_PATH` |  | If set, this directory will be used as scratch workspace, e.g. storing the results before they get requested. If unset, a temporary created is created for this purpose. |
+|  | `DOCLING_SERVE_ARTIFACT_STORAGE_VERIFY_SSL` | `true` | Whether the server-managed artifact storage verifies TLS certificates. Set this to `false` for local HTTP or self-signed MinIO setups. |
 | `--enable-ui` | `DOCLING_SERVE_ENABLE_UI` | `false` | Enable the demonstrator UI. |
 |  | `DOCLING_SERVE_ENABLE_MANAGEMENT_ENDPOINTS` | `false` | If enabled, the `/v1/memory` endpoints will provide memory statistics, otherwise it will return a forbidden 403 error. |
 |  | `DOCLING_SERVE_SHOW_VERSION_INFO` | `true` | If enabled, the `/version` endpoint will provide the Docling package versions, otherwise it will return a forbidden 403 error. |

--- a/docs/deploy-examples/docling-serve-oauth.yaml
+++ b/docs/deploy-examples/docling-serve-oauth.yaml
@@ -91,7 +91,7 @@ spec:
               memory: 1Gi
           startupProbe:
             httpGet:
-              path: /ready
+              path: /livez
               port: http
               scheme: HTTPS
             initialDelaySeconds: 5
@@ -100,7 +100,7 @@ spec:
             timeoutSeconds: 2
           readinessProbe:
             httpGet:
-              path: /ready
+              path: /readyz
               port: http
               scheme: HTTPS
             periodSeconds: 5
@@ -109,7 +109,7 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /health
+              path: /livez
               port: http
               scheme: HTTPS
             initialDelaySeconds: 3

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,7 +20,7 @@ On top of the source of file (see below), both endpoints support the same parame
 | `ocr_lang` | List[str] or NoneType | List of languages used by the OCR engine. Note that each OCR engine has different values for the language names. String or list of strings. Optional, defaults to empty. |
 | `ocr_preset` | str | Preset ID for OCR engine. |
 | `ocr_custom_config` | Dict[str, Any] or NoneType | Custom configuration for OCR engine. Use this to specify engine-specific options beyond `ocr_lang`. Each OCR engine kind has its own configuration schema. |
-| `pdf_backend` | PdfBackend | The PDF backend to use. String. Allowed values: `pypdfium2`, `docling_parse`, `dlparse_v1`, `dlparse_v2`, `dlparse_v4`. Optional, defaults to `docling_parse`. |
+| `pdf_backend` | PdfBackend | The PDF backend to use. String. Allowed values: `pypdfium2`, `docling_parse`, `threaded_docling_parse`, `dlparse_v1`, `dlparse_v2`, `dlparse_v4`. Optional, defaults to `docling_parse`. |
 | `table_mode` | TableFormerMode | Mode to use for table structure, String. Allowed values: `fast`, `accurate`. Optional, defaults to accurate. |
 | `table_cell_matching` | bool | If true, matches table cells predictions back to PDF cells. Can break table output if PDF cells are merged across table columns. If false, let table structure model define the text cells, ignore PDF cells. |
 | `pipeline` | ProcessingPipeline | Choose the pipeline to process PDF or image files. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "docling-slim[remote-serving]>=2.88.0,<3.0.0",
+    "docling-slim[service-client]>=2.88.0,<3.0.0",
     "docling-core>=2.45.0",
     "docling-jobkit[kfp,rq,ray,vlm]>=1.20.0,<2.0.0",
     "fastapi[standard]<0.137.0",
@@ -180,8 +180,8 @@ pytorch-triton-rocm = [
   { index = "pytorch-rocm", marker = "sys_platform == 'linux'" },
 ]
 
-docling-slim = { git = "https://github.com/docling-project/docling/", rev = "cau/service-models-presigned-batch-prep" }
-docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "cau/presigned-url-target-result-models" }
+docling-slim = { git = "https://github.com/docling-project/docling/", rev = "cau/batch-endpoint-support" }
+docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "cau/batch-endpoint-support" }
 
 [[tool.uv.index]]
 name = "pytorch-pypi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "docling[remote-serving]>=2.88.0,<3.0.0",
+    "docling-slim[remote-serving]>=2.88.0,<3.0.0",
     "docling-core>=2.45.0",
     "docling-jobkit[kfp,rq,ray,vlm]>=1.20.0,<2.0.0",
     "fastapi[standard]<0.137.0",
@@ -180,8 +180,8 @@ pytorch-triton-rocm = [
   { index = "pytorch-rocm", marker = "sys_platform == 'linux'" },
 ]
 
-# docling = { git = "https://github.com/docling-project/docling/", rev = "main" }
-# docling-jobkit = { path = "../docling-jobkit", editable = true }
+docling-slim = { git = "https://github.com/docling-project/docling/", rev = "cau/service-models-presigned-batch-prep" }
+docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "cau/presigned-url-target-result-models" }
 
 [[tool.uv.index]]
 name = "pytorch-pypi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@ pytorch-triton-rocm = [
   { index = "pytorch-rocm", marker = "sys_platform == 'linux'" },
 ]
 
-docling-slim = { git = "https://github.com/docling-project/docling/", rev = "cau/batch-endpoint-support" }
+docling-slim = { git = "https://github.com/docling-project/docling/", rev = "cau/batch-endpoint-client-sdk-updates" }
 docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "cau/batch-endpoint-support" }
 
 [[tool.uv.index]]

--- a/tests/test_batch_endpoint.py
+++ b/tests/test_batch_endpoint.py
@@ -184,6 +184,7 @@ async def test_batch_endpoint_rejects_zip_target(app):
         )
 
     assert response.status_code == 422
+    assert "zip" in response.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_endpoint.py
+++ b/tests/test_batch_endpoint.py
@@ -58,7 +58,7 @@ class _FakeOrchestrator:
             processing_time=1.0,
             num_converted=1,
             num_succeeded=1,
-            num_partial_success=0,
+            num_partially_succeeded=0,
             num_failed=0,
         )
 
@@ -195,5 +195,5 @@ async def test_task_result_returns_presigned_artifact_response(app):
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["num_partial_success"] == 0
+    assert payload["num_partially_succeeded"] == 0
     assert payload["documents"][0]["source_index"] == 0

--- a/tests/test_batch_endpoint.py
+++ b/tests/test_batch_endpoint.py
@@ -1,0 +1,199 @@
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from docling.datamodel.base_models import ConversionStatus
+from docling.datamodel.service.responses import (
+    ArtifactRef,
+    DoclingTaskResult,
+    DocumentArtifactItem,
+    PresignedArtifactResult,
+)
+from docling.datamodel.service.targets import S3Target
+from docling.datamodel.service.tasks import TaskType
+from docling_jobkit.datamodel.task import Task
+
+
+class _FakeOrchestrator:
+    def __init__(self) -> None:
+        self.enqueued: list[dict] = []
+
+    async def enqueue(self, **kwargs):
+        self.enqueued.append(kwargs)
+        return Task(
+            task_id="task-batch",
+            task_type=kwargs["task_type"],
+            sources=kwargs["sources"],
+            target=kwargs["target"],
+            convert_options=kwargs["convert_options"],
+            callbacks=kwargs["callbacks"],
+            metadata=kwargs["metadata"],
+        )
+
+    async def get_queue_position(self, task_id: str):
+        del task_id
+        return 0
+
+    async def task_result(self, task_id: str):
+        del task_id
+        return DoclingTaskResult(
+            result=PresignedArtifactResult(
+                documents=[
+                    DocumentArtifactItem(
+                        source_index=0,
+                        source_uri="https://example.com/a.pdf",
+                        filename="a.pdf",
+                        status=ConversionStatus.SUCCESS,
+                        artifacts=[
+                            ArtifactRef(
+                                artifact_type="markdown",
+                                mime_type="text/markdown",
+                                uri="s3://converted/000000-a/a.md",
+                            )
+                        ],
+                    )
+                ]
+            ),
+            processing_time=1.0,
+            num_converted=1,
+            num_succeeded=1,
+            num_partial_success=0,
+            num_failed=0,
+        )
+
+    async def on_result_fetched(self, task_id: str):
+        del task_id
+
+
+@pytest.fixture
+def fake_orchestrator(monkeypatch):
+    from docling_serve import app as app_module
+
+    orchestrator = _FakeOrchestrator()
+    monkeypatch.setattr(
+        app_module.docling_serve_settings, "artifact_storage_enabled", True
+    )
+    monkeypatch.setattr(
+        app_module.docling_serve_settings, "max_sources_per_request", 10
+    )
+    monkeypatch.setattr(app_module, "get_async_orchestrator", lambda: orchestrator)
+    return orchestrator
+
+
+@pytest.fixture
+def app(fake_orchestrator):
+    from docling_serve import app as app_module
+
+    del fake_orchestrator
+    with patch.object(app_module, "setup_otel_instrumentation"):
+        return app_module.create_app()
+
+
+@pytest.mark.asyncio
+async def test_batch_endpoint_rejects_s3_source_with_presigned_target(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://app.io"
+    ) as client:
+        response = await client.post(
+            "/v1/convert/source/batch",
+            json={
+                "sources": [
+                    {
+                        "kind": "s3",
+                        "endpoint": "s3.example.com",
+                        "access_key": "key",
+                        "secret_key": "secret",
+                        "bucket": "documents",
+                    }
+                ],
+                "target": {"kind": "presigned_url"},
+            },
+        )
+
+    assert response.status_code == 422
+    assert "S3 sources require an S3 target" in response.text
+
+
+@pytest.mark.asyncio
+async def test_batch_endpoint_accepts_s3_source_with_s3_target(app, fake_orchestrator):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://app.io"
+    ) as client:
+        response = await client.post(
+            "/v1/convert/source/batch",
+            json={
+                "sources": [
+                    {
+                        "kind": "s3",
+                        "endpoint": "s3.example.com",
+                        "access_key": "key",
+                        "secret_key": "secret",
+                        "bucket": "documents",
+                    }
+                ],
+                "target": {
+                    "kind": "s3",
+                    "endpoint": "s3.example.com",
+                    "access_key": "key",
+                    "secret_key": "secret",
+                    "bucket": "converted",
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["task_type"] == TaskType.CONVERT
+    assert len(fake_orchestrator.enqueued[0]["sources"]) == 1
+    assert isinstance(fake_orchestrator.enqueued[0]["target"], S3Target)
+
+
+@pytest.mark.asyncio
+async def test_batch_endpoint_accepts_http_source_with_presigned_target(
+    app, fake_orchestrator
+):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://app.io"
+    ) as client:
+        response = await client.post(
+            "/v1/convert/source/batch",
+            json={
+                "sources": [
+                    {"kind": "http", "url": "https://example.com/a.pdf"},
+                    {"kind": "http", "url": "https://example.com/b.pdf"},
+                ],
+                "target": {"kind": "presigned_url"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert len(fake_orchestrator.enqueued[0]["sources"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_batch_endpoint_rejects_zip_target(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://app.io"
+    ) as client:
+        response = await client.post(
+            "/v1/convert/source/batch",
+            json={
+                "sources": [{"kind": "http", "url": "https://example.com/a.pdf"}],
+                "target": {"kind": "zip"},
+            },
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_task_result_returns_presigned_artifact_response(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://app.io"
+    ) as client:
+        response = await client.get("/v1/result/task-batch")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["num_partial_success"] == 0
+    assert payload["documents"][0]["source_index"] == 0

--- a/tests/test_orchestrator_factory_slice_parallelism.py
+++ b/tests/test_orchestrator_factory_slice_parallelism.py
@@ -133,6 +133,11 @@ def test_ray_config_passes_presigned_storage_when_enabled(monkeypatch):
     )
     monkeypatch.setattr(
         factory_module.docling_serve_settings,
+        "artifact_storage_verify_ssl",
+        False,
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
         "artifact_storage_bucket",
         "bucket-a",
     )
@@ -180,8 +185,9 @@ def test_ray_config_passes_presigned_storage_when_enabled(monkeypatch):
     config = orchestrator.config.s3_presigned_config
     assert config is not None
     assert config.s3_coords.endpoint == "s3.example.com"
+    assert config.s3_coords.verify_ssl is False
     assert config.s3_coords.bucket == "bucket-a"
-    assert config.s3_coords.access_key.get_secret_value() == "key-a"
-    assert config.s3_coords.secret_key.get_secret_value() == "secret-a"
+    assert config.s3_coords.access_key == "key-a"
+    assert config.s3_coords.secret_key == "secret-a"
     assert config.key_prefix == "converted/test/"
     assert config.url_expiration == 900

--- a/tests/test_orchestrator_factory_slice_parallelism.py
+++ b/tests/test_orchestrator_factory_slice_parallelism.py
@@ -1,0 +1,187 @@
+from unittest.mock import patch
+
+from docling_serve import orchestrator_factory as factory_module
+from docling_serve.settings import AsyncEngine
+
+
+class _CapturedConfig:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class _CapturedConverterManagerConfig:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class _FakeConverterManager:
+    def __init__(self, config):
+        self.config = config
+
+
+class _FakeRayOrchestrator:
+    def __init__(self, config, converter_manager):
+        self.config = config
+        self.converter_manager = converter_manager
+
+
+def _build_ray_orchestrator(
+    monkeypatch, *, max_concurrent_tasks, max_page_slice_parallelism
+):
+    factory_module.get_async_orchestrator.cache_clear()
+
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings, "eng_kind", AsyncEngine.RAY
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "eng_ray_max_concurrent_tasks",
+        max_concurrent_tasks,
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "eng_ray_max_page_slice_parallelism",
+        max_page_slice_parallelism,
+    )
+
+    with (
+        patch(
+            "docling_jobkit.convert.manager.DoclingConverterManagerConfig",
+            _CapturedConverterManagerConfig,
+        ),
+        patch(
+            "docling_jobkit.convert.manager.DoclingConverterManager",
+            _FakeConverterManager,
+        ),
+        patch(
+            "docling_jobkit.orchestrators.ray.config.RayOrchestratorConfig",
+            _CapturedConfig,
+        ),
+        patch(
+            "docling_jobkit.orchestrators.ray.orchestrator.RayOrchestrator",
+            _FakeRayOrchestrator,
+        ),
+    ):
+        return factory_module.get_async_orchestrator()
+
+
+def test_slice_parallelism_defaults_to_max_concurrent_tasks(monkeypatch):
+    orchestrator = _build_ray_orchestrator(
+        monkeypatch,
+        max_concurrent_tasks=8,
+        max_page_slice_parallelism=None,
+    )
+
+    assert orchestrator.config.max_page_slice_parallelism == 8
+
+
+def test_slice_parallelism_preserves_explicit_override(monkeypatch):
+    orchestrator = _build_ray_orchestrator(
+        monkeypatch,
+        max_concurrent_tasks=8,
+        max_page_slice_parallelism=3,
+    )
+
+    assert orchestrator.config.max_page_slice_parallelism == 3
+
+
+def test_ray_config_never_receives_none_slice_parallelism(monkeypatch):
+    orchestrator = _build_ray_orchestrator(
+        monkeypatch,
+        max_concurrent_tasks=5,
+        max_page_slice_parallelism=None,
+    )
+
+    assert orchestrator.config.max_page_slice_parallelism is not None
+
+
+def test_ray_config_omits_presigned_storage_when_disabled(monkeypatch):
+    orchestrator = _build_ray_orchestrator(
+        monkeypatch,
+        max_concurrent_tasks=5,
+        max_page_slice_parallelism=None,
+    )
+
+    assert orchestrator.config.s3_presigned_config is None
+
+
+def test_ray_config_passes_presigned_storage_when_enabled(monkeypatch):
+    factory_module.get_async_orchestrator.cache_clear()
+
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings, "eng_kind", AsyncEngine.RAY
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "eng_ray_max_concurrent_tasks",
+        5,
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "eng_ray_max_page_slice_parallelism",
+        None,
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_enabled",
+        True,
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_endpoint",
+        "s3.example.com",
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_bucket",
+        "bucket-a",
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_access_key",
+        "key-a",
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_secret_key",
+        "secret-a",
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_key_prefix",
+        "converted/test/",
+    )
+    monkeypatch.setattr(
+        factory_module.docling_serve_settings,
+        "artifact_storage_presign_ttl_seconds",
+        900,
+    )
+
+    with (
+        patch(
+            "docling_jobkit.convert.manager.DoclingConverterManagerConfig",
+            _CapturedConverterManagerConfig,
+        ),
+        patch(
+            "docling_jobkit.convert.manager.DoclingConverterManager",
+            _FakeConverterManager,
+        ),
+        patch(
+            "docling_jobkit.orchestrators.ray.config.RayOrchestratorConfig",
+            _CapturedConfig,
+        ),
+        patch(
+            "docling_jobkit.orchestrators.ray.orchestrator.RayOrchestrator",
+            _FakeRayOrchestrator,
+        ),
+    ):
+        orchestrator = factory_module.get_async_orchestrator()
+
+    config = orchestrator.config.s3_presigned_config
+    assert config is not None
+    assert config.s3_coords.endpoint == "s3.example.com"
+    assert config.s3_coords.bucket == "bucket-a"
+    assert config.s3_coords.access_key.get_secret_value() == "key-a"
+    assert config.s3_coords.secret_key.get_secret_value() == "secret-a"
+    assert config.key_prefix == "converted/test/"
+    assert config.url_expiration == 900

--- a/tests/test_orchestrator_factory_slice_parallelism.py
+++ b/tests/test_orchestrator_factory_slice_parallelism.py
@@ -189,5 +189,5 @@ def test_ray_config_passes_presigned_storage_when_enabled(monkeypatch):
     assert config.s3_coords.bucket == "bucket-a"
     assert config.s3_coords.access_key == "key-a"
     assert config.s3_coords.secret_key == "secret-a"
-    assert config.key_prefix == "converted/test/"
+    assert config.s3_coords.key_prefix == "converted/test/"
     assert config.url_expiration == 900

--- a/tests/test_service_policy.py
+++ b/tests/test_service_policy.py
@@ -1,9 +1,9 @@
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.datamodel.service.requests import (
-    ConvertDocumentsRequest,
     ConvertSourcesRequest,
     HttpSourceRequest,
     S3SourceRequest,
@@ -18,7 +18,7 @@ from docling_serve.policy import (
     validate_convert_options,
     validate_convert_request,
 )
-from docling_serve.settings import AsyncEngine, DoclingServeSettings
+from docling_serve.settings import DoclingServeSettings
 
 
 def test_convert_options_shim_points_to_shared_type():
@@ -46,35 +46,30 @@ def test_validate_convert_options_rejects_timeout_above_policy():
         validate_convert_options(ConvertDocumentsOptions(document_timeout=11), policy)
 
 
-def test_validate_convert_request_rejects_s3_without_kfp():
-    policy = build_service_policy(DoclingServeSettings(eng_kind=AsyncEngine.LOCAL))
-    request = ConvertDocumentsRequest(
-        options=ConvertDocumentsOptions(),
-        sources=[
-            S3SourceRequest(
+def test_convert_sources_request_rejects_s3_inputs_at_model_layer():
+    with pytest.raises(ValidationError):
+        ConvertSourcesRequest(
+            options=ConvertDocumentsOptions(),
+            sources=[
+                S3SourceRequest(
+                    endpoint="s3.example.com",
+                    access_key="key",
+                    secret_key="secret",
+                    bucket="bucket",
+                )
+            ],
+            target=S3Target(
                 endpoint="s3.example.com",
                 access_key="key",
                 secret_key="secret",
                 bucket="bucket",
-            )
-        ],
-        target=S3Target(
-            endpoint="s3.example.com",
-            access_key="key",
-            secret_key="secret",
-            bucket="bucket",
-        ),
-    )
-
-    with pytest.raises(
-        HTTPException, match='source kind "s3" requires engine kind "KFP"'
-    ):
-        validate_convert_request(request, policy)
+            ),
+        )
 
 
 def test_normalize_convert_request_preserves_sources_and_target():
     policy = build_service_policy(DoclingServeSettings())
-    request = ConvertDocumentsRequest(
+    request = ConvertSourcesRequest(
         options=ConvertDocumentsOptions(document_timeout=None),
         sources=[HttpSourceRequest(url="https://example.com/test.pdf", headers={})],
         target=InBodyTarget(),

--- a/tests/test_service_policy.py
+++ b/tests/test_service_policy.py
@@ -4,6 +4,7 @@ from pydantic import ValidationError
 
 from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.datamodel.service.requests import (
+    BatchConvertSourcesRequest,
     ConvertSourcesRequest,
     HttpSourceRequest,
     S3SourceRequest,
@@ -13,8 +14,10 @@ from docling.datamodel.service.targets import InBodyTarget, PresignedUrlTarget, 
 from docling_serve.datamodel.convert import ConvertDocumentsRequestOptions
 from docling_serve.policy import (
     build_service_policy,
+    normalize_batch_convert_request,
     normalize_convert_options,
     normalize_convert_request,
+    validate_batch_convert_request,
     validate_convert_options,
     validate_convert_request,
 )
@@ -137,3 +140,75 @@ def test_validate_convert_request_allows_presigned_url_when_storage_enabled():
     )
 
     validate_convert_request(request, policy)
+
+
+def test_validate_batch_convert_request_rejects_s3_source_with_presigned_target():
+    policy = build_service_policy(DoclingServeSettings(artifact_storage_enabled=True))
+    request = BatchConvertSourcesRequest(
+        sources=[
+            S3SourceRequest(
+                endpoint="s3.example.com",
+                access_key="key",
+                secret_key="secret",
+                bucket="bucket",
+            )
+        ],
+        target=PresignedUrlTarget(),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        validate_batch_convert_request(request, policy)
+
+    assert exc_info.value.status_code == 422
+    assert "S3 sources require an S3 target" in exc_info.value.detail
+
+
+def test_validate_batch_convert_request_allows_s3_source_with_s3_target_without_kfp():
+    policy = build_service_policy(DoclingServeSettings())
+    request = BatchConvertSourcesRequest(
+        sources=[
+            S3SourceRequest(
+                endpoint="s3.example.com",
+                access_key="key",
+                secret_key="secret",
+                bucket="bucket",
+            )
+        ],
+        target=S3Target(
+            endpoint="s3.example.com",
+            access_key="key",
+            secret_key="secret",
+            bucket="converted",
+        ),
+    )
+
+    validate_batch_convert_request(request, policy)
+
+
+def test_validate_batch_convert_request_allows_http_source_with_s3_target():
+    policy = build_service_policy(DoclingServeSettings())
+    request = BatchConvertSourcesRequest(
+        sources=[HttpSourceRequest(url="https://example.com/test.pdf", headers={})],
+        target=S3Target(
+            endpoint="s3.example.com",
+            access_key="key",
+            secret_key="secret",
+            bucket="converted",
+        ),
+    )
+
+    validate_batch_convert_request(request, policy)
+
+
+def test_normalize_batch_convert_request_sets_default_timeout():
+    policy = build_service_policy(DoclingServeSettings())
+    request = BatchConvertSourcesRequest(
+        options=ConvertDocumentsOptions(document_timeout=None),
+        sources=[HttpSourceRequest(url="https://example.com/test.pdf", headers={})],
+        target=PresignedUrlTarget(),
+    )
+
+    normalized = normalize_batch_convert_request(request, policy)
+
+    assert isinstance(normalized, BatchConvertSourcesRequest)
+    assert normalized.options.document_timeout == policy.max_document_timeout

--- a/tests/test_service_policy.py
+++ b/tests/test_service_policy.py
@@ -14,9 +14,8 @@ from docling.datamodel.service.targets import InBodyTarget, PresignedUrlTarget, 
 from docling_serve.datamodel.convert import ConvertDocumentsRequestOptions
 from docling_serve.policy import (
     build_service_policy,
-    normalize_batch_convert_request,
     normalize_convert_options,
-    normalize_convert_request,
+    normalize_request,
     validate_batch_convert_request,
     validate_convert_options,
     validate_convert_request,
@@ -49,6 +48,67 @@ def test_validate_convert_options_rejects_timeout_above_policy():
         validate_convert_options(ConvertDocumentsOptions(document_timeout=11), policy)
 
 
+def test_validate_convert_options_rejects_images_scale_above_policy():
+    policy = build_service_policy(DoclingServeSettings(max_images_scale=1.5))
+
+    with pytest.raises(HTTPException, match="images_scale exceeds"):
+        validate_convert_options(ConvertDocumentsOptions(images_scale=1.6), policy)
+
+
+def test_validate_convert_options_allows_all_image_modes_by_default():
+    policy = build_service_policy(DoclingServeSettings())
+
+    # All three modes should be allowed by default
+    validate_convert_options(
+        ConvertDocumentsOptions(image_export_mode="placeholder"), policy
+    )
+    validate_convert_options(
+        ConvertDocumentsOptions(image_export_mode="referenced"), policy
+    )
+    validate_convert_options(
+        ConvertDocumentsOptions(image_export_mode="embedded"), policy
+    )
+
+
+def test_validate_convert_options_rejects_disallowed_image_mode():
+    policy = build_service_policy(
+        DoclingServeSettings(allowed_image_export_modes=["placeholder", "referenced"])
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        validate_convert_options(
+            ConvertDocumentsOptions(image_export_mode="embedded"), policy
+        )
+
+    assert exc_info.value.status_code == 422
+    assert "image_export_mode 'embedded' is not allowed" in exc_info.value.detail
+    assert "placeholder" in exc_info.value.detail
+    assert "referenced" in exc_info.value.detail
+
+
+def test_validate_convert_options_allows_configured_image_mode():
+    policy = build_service_policy(
+        DoclingServeSettings(allowed_image_export_modes=["placeholder"])
+    )
+
+    # Should allow placeholder
+    validate_convert_options(
+        ConvertDocumentsOptions(image_export_mode="placeholder"), policy
+    )
+
+    # Should reject others
+    with pytest.raises(HTTPException, match="image_export_mode.*not allowed"):
+        validate_convert_options(
+            ConvertDocumentsOptions(image_export_mode="referenced"), policy
+        )
+
+
+def test_validate_convert_options_allows_images_scale_at_policy_cap():
+    policy = build_service_policy(DoclingServeSettings(max_images_scale=2.0))
+
+    validate_convert_options(ConvertDocumentsOptions(images_scale=2.0), policy)
+
+
 def test_convert_sources_request_rejects_s3_inputs_at_model_layer():
     with pytest.raises(ValidationError):
         ConvertSourcesRequest(
@@ -78,7 +138,7 @@ def test_normalize_convert_request_preserves_sources_and_target():
         target=InBodyTarget(),
     )
 
-    normalized = normalize_convert_request(request, policy)
+    normalized = normalize_request(request, policy)
 
     assert normalized.sources == request.sources
     assert normalized.target == request.target
@@ -93,7 +153,7 @@ def test_normalize_convert_request_works_for_convert_sources_request():
         target=InBodyTarget(),
     )
 
-    normalized = normalize_convert_request(request, policy)
+    normalized = normalize_request(request, policy)
 
     assert isinstance(normalized, ConvertSourcesRequest)
     assert normalized.sources == request.sources
@@ -208,7 +268,7 @@ def test_normalize_batch_convert_request_sets_default_timeout():
         target=PresignedUrlTarget(),
     )
 
-    normalized = normalize_batch_convert_request(request, policy)
+    normalized = normalize_request(request, policy)
 
     assert isinstance(normalized, BatchConvertSourcesRequest)
     assert normalized.options.document_timeout == policy.max_document_timeout

--- a/tests/test_service_policy.py
+++ b/tests/test_service_policy.py
@@ -110,7 +110,7 @@ def test_validate_convert_request_rejects_presigned_url_when_storage_disabled():
     with pytest.raises(HTTPException) as exc_info:
         validate_convert_request(request, policy)
 
-    assert exc_info.value.status_code == 503
+    assert exc_info.value.status_code == 422
     assert "artifact storage" in exc_info.value.detail.lower()
 
 

--- a/tests/test_service_policy.py
+++ b/tests/test_service_policy.py
@@ -4,10 +4,11 @@ from fastapi import HTTPException
 from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.datamodel.service.requests import (
     ConvertDocumentsRequest,
+    ConvertSourcesRequest,
     HttpSourceRequest,
     S3SourceRequest,
 )
-from docling.datamodel.service.targets import InBodyTarget, S3Target
+from docling.datamodel.service.targets import InBodyTarget, PresignedUrlTarget, S3Target
 
 from docling_serve.datamodel.convert import ConvertDocumentsRequestOptions
 from docling_serve.policy import (
@@ -84,3 +85,60 @@ def test_normalize_convert_request_preserves_sources_and_target():
     assert normalized.sources == request.sources
     assert normalized.target == request.target
     assert normalized.options.document_timeout == policy.max_document_timeout
+
+
+def test_normalize_convert_request_works_for_convert_sources_request():
+    policy = build_service_policy(DoclingServeSettings())
+    request = ConvertSourcesRequest(
+        options=ConvertDocumentsOptions(document_timeout=None),
+        sources=[HttpSourceRequest(url="https://example.com/test.pdf", headers={})],
+        target=InBodyTarget(),
+    )
+
+    normalized = normalize_convert_request(request, policy)
+
+    assert isinstance(normalized, ConvertSourcesRequest)
+    assert normalized.sources == request.sources
+    assert normalized.options.document_timeout == policy.max_document_timeout
+
+
+def test_validate_convert_request_rejects_presigned_url_when_storage_disabled():
+    policy = build_service_policy(DoclingServeSettings(artifact_storage_enabled=False))
+    request = ConvertSourcesRequest(
+        sources=[HttpSourceRequest(url="https://example.com/test.pdf", headers={})],
+        target=PresignedUrlTarget(),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        validate_convert_request(request, policy)
+
+    assert exc_info.value.status_code == 503
+    assert "artifact storage" in exc_info.value.detail.lower()
+
+
+def test_validate_convert_request_rejects_too_many_sources():
+    policy = build_service_policy(DoclingServeSettings(max_sources_per_request=2))
+    request = ConvertSourcesRequest(
+        sources=[
+            HttpSourceRequest(url="https://example.com/a.pdf", headers={}),
+            HttpSourceRequest(url="https://example.com/b.pdf", headers={}),
+            HttpSourceRequest(url="https://example.com/c.pdf", headers={}),
+        ],
+        target=InBodyTarget(),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        validate_convert_request(request, policy)
+
+    assert exc_info.value.status_code == 422
+    assert "Too many sources" in exc_info.value.detail
+
+
+def test_validate_convert_request_allows_presigned_url_when_storage_enabled():
+    policy = build_service_policy(DoclingServeSettings(artifact_storage_enabled=True))
+    request = ConvertSourcesRequest(
+        sources=[HttpSourceRequest(url="https://example.com/test.pdf", headers={})],
+        target=PresignedUrlTarget(),
+    )
+
+    validate_convert_request(request, policy)


### PR DESCRIPTION
## Summary

This PR adds the `docling-serve` API and policy support for server-managed artifact delivery and remote batch conversion.

It wires `PresignedUrlTarget` through the regular convert endpoints, adds the async `POST /v1/convert/source/batch` endpoint, injects managed artifact-storage config into the async orchestrators, hardens endpoint validation around source/target combinations and request limits, and adds serve-side policy controls for image export modes and `images_scale`.

## What This PR Does

- Adds `PresignedUrlTarget` support on the regular convert endpoints:
  - `/v1/convert/source`
  - `/v1/convert/file`
  - `/v1/result/{task_id}`
- Returns full artifact manifests for presigned-target tasks via `PresignedUrlConvertResponse`, rather than only the legacy remote-target summary response.
- Builds `S3PresignedConfig` from `docling-serve` settings and passes it into the local, RQ, and Ray orchestrators so jobkit can write managed artifacts and return presigned URLs.
- Adds `POST /v1/convert/source/batch` as an async-only endpoint using `BatchConvertSourcesRequest`.
- Allows batch inputs to be remote HTTP sources or S3 sources, with target behavior driven by target type:
  - `PresignedUrlTarget` returns artifact manifests
  - `S3Target` returns the existing summary-style remote-target response
- Enforces batch S3 routing rules:
  - S3 sources are allowed on the batch endpoint
  - S3 sources must target `S3Target`
  - HTTP batch sources may target either `PresignedUrlTarget` or `S3Target`
- Hardens the regular convert endpoints:
  - regular source requests now use `ConvertSourcesRequest`
  - regular `/v1/convert/source` excludes S3 inputs at the request-model layer
  - regular `HttpSourceRequest` continues to reject ZIP URLs
  - request count is capped by `max_sources_per_request`
- Extends file upload endpoints so `target_type=presigned_url` is supported when artifact storage is enabled.
- Explicitly rejects `presigned_url` on chunk endpoints.
- Surfaces `num_partially_succeeded` on result responses for both presigned-target and remote-target flows.
- Adds serve-side image export policy controls:
  - `allowed_image_export_modes`
  - `max_images_scale`
- Cleans up logging setup so the colored formatter lives in `logging_config.py`, avoiding the recursive import / double-output issue.
- Updates version reporting to use `docling-slim` as the `docling` package source.

## Request and Response Semantics

- `PresignedUrlTarget` is a server-managed delivery mode. Clients do not provide storage credentials; the server uploads artifacts and returns time-limited URLs.
- Regular convert endpoints now advertise three result families:
  - in-body document response
  - legacy remote-target summary response
  - presigned artifact-list response
- Batch conversion is target-driven, not endpoint-driven:
  - `PresignedUrlTarget` batch tasks return `PresignedUrlConvertResponse`
  - `S3Target` batch tasks return the existing summary-style remote-target response
- `TaskStatusResponse` and final result surfaces both carry partial-success counts.

## Configuration and Policy

New or newly enforced serve settings:

- `artifact_storage_enabled`
- `artifact_storage_endpoint`
- `artifact_storage_verify_ssl`
- `artifact_storage_bucket`
- `artifact_storage_access_key`
- `artifact_storage_secret_key`
- `artifact_storage_key_prefix`
- `artifact_storage_presign_ttl_seconds`
- `max_sources_per_request`
- `allowed_image_export_modes`
- `max_images_scale`

Policy behavior added here:

- reject `PresignedUrlTarget` when artifact storage is not configured
- reject requests that exceed `max_sources_per_request`
- reject `images_scale` above policy cap
- reject disallowed `image_export_mode` values
- reject `presigned_url` on chunk endpoints
- enforce `S3 source -> S3 target` on the batch endpoint

## Cross-Repo Alignment

This PR is the `docling-serve` side of the shared batch/presigned-target work:

- `docling`: shared request, target, and response models
- `docling-jobkit`: presigned artifact handling, remote target processing, batch S3 execution, and partial-success propagation

The branch is pinned to the matching `docling-slim` and `docling-jobkit` revisions in `pyproject.toml`.

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
