### PR TITLE
feat: add support for ROCm 7.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,13 @@ docling-serve-rocm-image: Containerfile ## Build docling-serve container image w
 	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-rocm:$(TAG) ghcr.io/docling-project/docling-serve-rocm:$(BRANCH_TAG)
 	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-rocm:$(TAG) quay.io/docling-project/docling-serve-rocm:$(BRANCH_TAG)
 
+.PHONY: docling-serve-rocm72-image
+docling-serve-rocm72-image: Containerfile ## Build docling-serve container image with ROCm 7.2 support
+	$(ECHO_PREFIX) printf "  %-12s Containerfile\n" "[docling-serve with ROCm 7.2]"
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) build --load --build-arg "UV_SYNC_EXTRA_ARGS=--no-group pypi --group rocm72 --no-extra flash-attn" -f Containerfile --platform linux/amd64 -t ghcr.io/docling-project/docling-serve-rocm72:$(TAG) .
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-rocm72:$(TAG) ghcr.io/docling-project/docling-serve-rocm72:$(BRANCH_TAG)
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) tag ghcr.io/docling-project/docling-serve-rocm72:$(TAG) quay.io/docling-project/docling-serve-rocm72:$(BRANCH_TAG)
+
 .PHONY: action-lint
 action-lint: .action-lint ##      Lint GitHub Action workflows
 .action-lint: $(shell find .github -type f) | action-lint-file
@@ -152,3 +159,17 @@ run-docling-rocm: ## Run the docling-serve container with GPU support and assign
 	$(CMD_PREFIX) $(CONTAINER_RUNTIME) rm -f docling-serve-rocm 2>/dev/null || true
 	$(ECHO_PREFIX) printf "  %-12s Running docling-serve container with GPU support on port 5001...\n" "[RUN ROCm 6.3]"
 	$(CMD_PREFIX) $(CONTAINER_RUNTIME) run -it --name docling-serve-rocm -p 5001:5001 ghcr.io/docling-project/docling-serve-rocm:main
+
+.PHONY: run-docling-rocm72
+run-docling-rocm72: ## Run the docling-serve container with ROCm 7.2 support and assign a container name
+	$(ECHO_PREFIX) printf "  %-12s Removing existing container if it exists...\n" "[CLEANUP]"
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) rm -f docling-serve-rocm72 2>/dev/null || true
+	$(ECHO_PREFIX) printf "  %-12s Running docling-serve container with ROCm 7.2 support on port 5001...\n" "[RUN ROCm 7.2]"
+	$(CMD_PREFIX) $(CONTAINER_RUNTIME) run -it --name docling-serve-rocm72 -p 5001:5001 \
+		--device /dev/kfd:/dev/kfd \
+		--device /dev/dri:/dev/dri \
+		--group-add $(shell getent group video | cut -d: -f3) \
+		--group-add $(shell getent group render | cut -d: -f3) \
+		-e TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1 \
+		-e DOCLING_SERVE_ENABLE_UI=true \
+		ghcr.io/docling-project/docling-serve-rocm72:main

--- a/docs/deploy-examples/compose-amd.yaml
+++ b/docs/deploy-examples/compose-amd.yaml
@@ -2,7 +2,7 @@
 
 services:
   docling-serve:
-    image: ghcr.io/docling-project/docling-serve-rocm:main
+    image: ghcr.io/docling-project/docling-serve-rocm72:main
     container_name: docling-serve
     ports:
       - "5001:5001"
@@ -12,6 +12,8 @@ services:
       ## This section is for compatibility with older cards
       # HSA_OVERRIDE_GFX_VERSION: "11.0.0"
       # HSA_ENABLE_SDMA: "0"
+      ## Enable experimental Flash/Mem-Efficient attention kernels on AMD GPU (aotriton).
+      TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL: "1"
     devices:
       - /dev/kfd:/dev/kfd
       - /dev/dri:/dev/dri

--- a/os-packages.txt
+++ b/os-packages.txt
@@ -5,3 +5,4 @@ tesseract-osd
 leptonica-devel
 libglvnd-glx
 glib2
+libatomic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,12 @@ rocm = [
   "pytorch-triton-rocm>=3.3.1 ; sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
 
+rocm72 = [
+    "torch>=2.7.1 ; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "torchvision>=0.22.1 ; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "triton-rocm ; sys_platform == 'linux' and platform_machine == 'x86_64'",
+]
+
 [[tool.uv.dependency-metadata]]
 name = "flash-attn"
 version = "2.8.3"
@@ -145,6 +151,7 @@ conflicts = [
     { group = "cu128" },
     { group = "cu130" },
     { group = "rocm" },
+    { group = "rocm72" },
   ],
 ]
 environments = ["sys_platform != 'darwin' or platform_machine != 'x86_64'"]
@@ -164,6 +171,7 @@ torch = [
   { index = "pytorch-cu128", group = "cu128", marker = "sys_platform == 'linux'" },
   { index = "pytorch-cu130", group = "cu130", marker = "sys_platform == 'linux'" },
   { index = "pytorch-rocm", group = "rocm", marker = "sys_platform == 'linux'" },
+  { index = "pytorch-rocm72", group = "rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
 ]
 
 torchvision = [
@@ -174,10 +182,15 @@ torchvision = [
   { index = "pytorch-cu128", group = "cu128", marker = "sys_platform == 'linux'" },
   { index = "pytorch-cu130", group = "cu130", marker = "sys_platform == 'linux'" },
   { index = "pytorch-rocm", group = "rocm", marker = "sys_platform == 'linux'" },
+  { index = "pytorch-rocm72", group = "rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
 ]
 
 pytorch-triton-rocm = [
   { index = "pytorch-rocm", marker = "sys_platform == 'linux'" },
+]
+
+triton-rocm = [
+    { index = "pytorch-rocm72", group = "rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" }
 ]
 
 # docling = { git = "https://github.com/docling-project/docling/", rev = "main" }
@@ -216,6 +229,11 @@ explicit = true
 [[tool.uv.index]]
 name = "pytorch-rocm"
 url = "https://download.pytorch.org/whl/rocm6.3"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-rocm72"
+url = "https://download.pytorch.org/whl/rocm7.2"
 explicit = true
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Adds a new `rocm72` variant of the docling-serve container image targeting AMD GPUs on ROCm 7.2 (tested on AMD Strix Halo iGPU).

## Changes
1. Added rocm7.2 to pyproject.toml, Makefile and compose-amd.yaml
2. added `libatomic` to os-packages.txt because it is required by PyTorch/ROCm runtime (AMD wheels do not bundle it?)

## Notes:
I am not very experienced with docling, i tried couple of arxiv pdf's and they worked. Docling provides several modes:
1. standard pipeline - work ok, but triggers RapidOCR. By default it uses onnxruntime. There is onxxruntime-migraphx targeting AMD ROCm but atm RapidOCR doesn't support it out of the box. I tried to use for sake of experiment in different environment and it didn't provide any benefit (i guess models are too small?)
2. VLM pipeline, using `granite-docling-258M` i had stability/performance issues, and not quite sure what is problem. I tried to run it in separate environment but had no success. I think it's better to point to remote VLM model (using some other inference engine, in strixhalo it would be llama.cpp).

**Issue resolved by this Pull Request:**
Resolves #475 
