### PR TITLE
fix: Normalize include_images options when using image_export_mode `placeholder`

### DIFF
--- a/docling_serve/policy.py
+++ b/docling_serve/policy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from fastapi import HTTPException, status
 
@@ -14,6 +14,7 @@ from docling.datamodel.service.requests import (
 )
 from docling.datamodel.service.targets import PresignedUrlTarget, S3Target
 from docling.models.factories import get_ocr_factory
+from docling_core.types.doc import ImageRefMode
 
 from docling_serve.settings import AsyncEngine, DoclingServeSettings
 
@@ -83,11 +84,24 @@ def build_service_policy(settings: DoclingServeSettings) -> ServicePolicy:
 def normalize_convert_options(
     options: ConvertDocumentsOptions, policy: ServicePolicy
 ) -> ConvertDocumentsOptions:
-    if options.document_timeout is not None:
+    updates: dict[str, Any] = {}
+
+    if options.document_timeout is None:
+        updates["document_timeout"] = policy.max_document_timeout
+
+    # Placeholder export mode discards all image data, so generating images would
+    # be wasted work. Coerce the include_* flags off rather than rejecting the
+    # request: include_images defaults to True, so a 422 here would fail requests
+    # purely on a default the caller never set.
+    if options.image_export_mode == ImageRefMode.PLACEHOLDER:
+        if options.include_images:
+            updates["include_images"] = False
+        if options.include_page_images:
+            updates["include_page_images"] = False
+
+    if not updates:
         return options
-    return options.model_copy(
-        update={"document_timeout": policy.max_document_timeout}, deep=True
-    )
+    return options.model_copy(update=updates, deep=True)
 
 
 def normalize_request(

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,7 @@ On top of the source of file (see below), both endpoints support the same parame
 
 | Field Name | Type | Description |
 |------------|------|-------------|
-| `from_formats` | List[InputFormat] | Input format(s) to convert from. String or list of strings. Allowed values: `docx`, `pptx`, `html`, `image`, `pdf`, `asciidoc`, `md`, `csv`, `xlsx`, `xml_uspto`, `xml_jats`, `xml_xbrl`, `mets_gbs`, `json_docling`, `audio`, `vtt`, `latex`, `email`. Optional, defaults to all formats. |
+| `from_formats` | List[InputFormat] | Input format(s) to convert from. String or list of strings. Allowed values: `docx`, `pptx`, `html`, `image`, `pdf`, `asciidoc`, `md`, `csv`, `xlsx`, `xml_uspto`, `xml_jats`, `xml_xbrl`, `mets_gbs`, `json_docling`, `audio`, `vtt`, `latex`, `email`, `epub`. Optional, defaults to all formats. |
 | `to_formats` | List[OutputFormat] | Output format(s) to convert to. String or list of strings. Allowed values: `md`, `json`, `yaml`, `html`, `html_split_page`, `text`, `doctags`, `vtt`. Optional, defaults to Markdown. |
 | `image_export_mode` | ImageRefMode | Image export mode for the document (in case of JSON, Markdown or HTML). Allowed values: `placeholder`, `embedded`, `referenced`. Optional, defaults to Embedded. |
 | `do_ocr` | bool | If enabled, the bitmap content will be processed using OCR. Boolean. Optional, defaults to true |
@@ -28,7 +28,8 @@ On top of the source of file (see below), both endpoints support the same parame
 | `document_timeout` | float or NoneType | The timeout for processing each document, in seconds. |
 | `abort_on_error` | bool | Abort on error if enabled. Boolean. Optional, defaults to false. |
 | `do_table_structure` | bool | If enabled, the table structure will be extracted. Boolean. Optional, defaults to true. |
-| `include_images` | bool | If enabled, images will be extracted from the document. Boolean. Optional, defaults to true. |
+| `include_images` | bool | If enabled, picture element images are generated and included in the output. Boolean. Optional, defaults to true. |
+| `include_page_images` | bool | If enabled, full-page images are generated and included in the output. Boolean. Optional, defaults to false. |
 | `images_scale` | float | Scale factor for images. Float. Optional, defaults to 2.0. |
 | `md_page_break_placeholder` | str | Add this placeholder between pages in the markdown output. |
 | `do_code_enrichment` | bool | If enabled, perform OCR code enrichment. Boolean. Optional, defaults to false. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,8 +11,8 @@ On top of the source of file (see below), both endpoints support the same parame
 
 | Field Name | Type | Description |
 |------------|------|-------------|
-| `from_formats` | List[InputFormat] | Input format(s) to convert from. String or list of strings. Allowed values: `docx`, `pptx`, `html`, `image`, `pdf`, `asciidoc`, `md`, `csv`, `xlsx`, `xml_uspto`, `xml_jats`, `xml_xbrl`, `mets_gbs`, `json_docling`, `audio`, `vtt`, `latex`, `email`, `epub`. Optional, defaults to all formats. |
-| `to_formats` | List[OutputFormat] | Output format(s) to convert to. String or list of strings. Allowed values: `md`, `json`, `yaml`, `html`, `html_split_page`, `text`, `doctags`, `vtt`. Optional, defaults to Markdown. |
+| `from_formats` | List[InputFormat] | Input format(s) to convert from. String or list of strings. Allowed values: `docx`, `pptx`, `html`, `image`, `pdf`, `asciidoc`, `md`, `csv`, `xlsx`, `xml_uspto`, `xml_jats`, `xml_xbrl`, `xml_doclang`, `mets_gbs`, `json_docling`, `audio`, `vtt`, `latex`, `email`, `epub`. Optional, defaults to all formats. |
+| `to_formats` | List[OutputFormat] | Output format(s) to convert to. String or list of strings. Allowed values: `md`, `json`, `yaml`, `html`, `html_split_page`, `text`, `doctags`, `vtt`, `doclang`. Optional, defaults to Markdown. |
 | `image_export_mode` | ImageRefMode | Image export mode for the document (in case of JSON, Markdown or HTML). Allowed values: `placeholder`, `embedded`, `referenced`. Optional, defaults to Embedded. |
 | `do_ocr` | bool | If enabled, the bitmap content will be processed using OCR. Boolean. Optional, defaults to true |
 | `force_ocr` | bool | If enabled, replace existing text with OCR-generated text over content. Boolean. Optional, defaults to false. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "docling-slim[service-client]>=2.99.0,<3.0.0",
+    "docling-slim[standard,service-client,remote-serving]>=2.101.0,<3.0.0",
     "docling-core>=2.79.0",
-    "docling-jobkit[kfp,rq,ray,vlm]>=1.21.0,<2.0.0",
+    "docling-jobkit[rq,ray,vlm]>=1.22.0,<2.0.0",
     "fastapi[standard]<0.137.0",
     "httpx~=0.28",
     "pydantic~=2.10",
@@ -189,13 +189,12 @@ pytorch-triton-rocm = [
   { index = "pytorch-rocm", marker = "sys_platform == 'linux'" },
 ]
 
-docling-slim = { git = "https://github.com/docling-project/docling/", rev = "cau/consistent-image-inclusion" }
-docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "cau/consistent-image-inclusion" }
 triton-rocm = [
     { index = "pytorch-rocm72", group = "rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" }
 ]
 
-# docling = { git = "https://github.com/docling-project/docling/", rev = "main" }
+# docling-slim = { git = "https://github.com/docling-project/docling/", rev = "main" }
+# docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "main" }
 # docling-jobkit = { path = "../docling-jobkit", editable = true }
 
 [[tool.uv.index]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,8 +189,8 @@ pytorch-triton-rocm = [
   { index = "pytorch-rocm", marker = "sys_platform == 'linux'" },
 ]
 
-# docling-slim = { git = "https://github.com/docling-project/docling/", rev = "main" }
-# docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "main" }
+docling-slim = { git = "https://github.com/docling-project/docling/", rev = "cau/consistent-image-inclusion" }
+docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "cau/consistent-image-inclusion" }
 triton-rocm = [
     { index = "pytorch-rocm72", group = "rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" }
 ]

--- a/tests/test_service_policy.py
+++ b/tests/test_service_policy.py
@@ -43,6 +43,36 @@ def test_normalize_convert_options_sets_default_timeout():
     assert normalized.document_timeout == policy.max_document_timeout
 
 
+def test_normalize_convert_options_placeholder_disables_images():
+    policy = build_service_policy(DoclingServeSettings())
+
+    # include_images defaults to True; placeholder must not fail on that default,
+    # it should coerce the include_* flags off instead.
+    normalized = normalize_convert_options(
+        ConvertDocumentsOptions(
+            image_export_mode="placeholder", include_page_images=True
+        ),
+        policy,
+    )
+
+    assert normalized.include_images is False
+    assert normalized.include_page_images is False
+
+
+def test_normalize_convert_options_preserves_images_for_non_placeholder():
+    policy = build_service_policy(DoclingServeSettings())
+
+    normalized = normalize_convert_options(
+        ConvertDocumentsOptions(
+            image_export_mode="referenced", include_page_images=True
+        ),
+        policy,
+    )
+
+    assert normalized.include_images is True
+    assert normalized.include_page_images is True
+
+
 def test_build_service_policy_allows_all_target_types_by_default():
     policy = build_service_policy(DoclingServeSettings())
 


### PR DESCRIPTION
This saves processing from doing unnecessary work without side effects.

see: https://github.com/docling-project/docling-jobkit/pull/169

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
