### PR TITLE
fix: Enforce tenant ownership on task read endpoints

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -1320,26 +1320,21 @@ def create_app():  # noqa: C901
         orchestrator: Annotated[BaseOrchestrator, Depends(get_async_orchestrator)],
         task_id: str,
         api_key: Annotated[str, Query()] = "",
-        x_api_key: Annotated[str | None, Header(alias=require_auth.header_name)] = None,
-        x_tenant_id: Annotated[
-            str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
-        ] = None,
+        tenant_id: Annotated[str | None, Query()] = None,
     ):
         if docling_serve_settings.api_key:
-            # Prefer the API key from the header; fall back to the query
-            # parameter for browser clients that cannot set headers. Note that
-            # query-parameter keys may be captured in proxy/access logs.
-            provided_key = x_api_key if x_api_key is not None else api_key
-            if provided_key != docling_serve_settings.api_key:
+            # WebSocket clients on this endpoint authenticate via query
+            # parameter. Note that query-parameter keys may be captured in
+            # proxy/access logs.
+            if api_key != docling_serve_settings.api_key:
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail=(
-                        f"Api key is required as the {require_auth.header_name} "
-                        "header or ?api_key=SECRET query parameter."
+                        "Api key is required as the ?api_key=SECRET query parameter."
                     ),
                 )
 
-        tenant_id = _get_tenant_id_from_header(x_tenant_id)
+        tenant_id = tenant_id or "default"
 
         assert isinstance(orchestrator.notifier, WebsocketNotifier)
         await websocket.accept()

--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -509,6 +509,27 @@ def create_app():  # noqa: C901
         )
         return tenant_id
 
+    def _task_tenant_id(task: Task) -> str:
+        """Return the tenant that owns a task, defaulting to 'default'."""
+        return (task.metadata or {}).get("tenant_id") or "default"
+
+    def _assert_task_tenant(task: Task, tenant_id: str) -> None:
+        """Ensure the caller's tenant owns the task.
+
+        Raises TaskNotFoundError (surfaced as 404) on mismatch rather than 403
+        so a caller cannot probe whether a task UUID exists for another tenant.
+
+        When tenants are not in use, every task is owned by 'default' and every
+        caller resolves to 'default', so this check is transparent.
+        """
+        owner_tenant_id = _task_tenant_id(task)
+        if owner_tenant_id != tenant_id:
+            _log.warning(
+                f"[TENANT_ID] Tenant mismatch for task {task.task_id}: "
+                f"caller='{tenant_id}' owner='{owner_tenant_id}' - denying access"
+            )
+            raise TaskNotFoundError()
+
     async def _wait_task_complete(orchestrator: BaseOrchestrator, task_id: str) -> bool:
         start_time = time.monotonic()
         while True:
@@ -1265,13 +1286,18 @@ def create_app():  # noqa: C901
         auth: Annotated[AuthenticationResult, Depends(require_auth)],
         orchestrator: Annotated[BaseOrchestrator, Depends(get_async_orchestrator)],
         task_id: str,
+        x_tenant_id: Annotated[
+            str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
+        ] = None,
         wait: Annotated[
             float,
             Query(description="Number of seconds to wait for a completed status."),
         ] = 0.0,
     ):
+        tenant_id = _get_tenant_id_from_header(x_tenant_id)
         try:
             task = await orchestrator.task_status(task_id=task_id, wait=wait)
+            _assert_task_tenant(task, tenant_id)
             task_queue_position = await orchestrator.get_queue_position(task_id=task_id)
         except TaskNotFoundError:
             raise HTTPException(status_code=404, detail="Task not found.")
@@ -1294,19 +1320,33 @@ def create_app():  # noqa: C901
         orchestrator: Annotated[BaseOrchestrator, Depends(get_async_orchestrator)],
         task_id: str,
         api_key: Annotated[str, Query()] = "",
+        x_api_key: Annotated[str | None, Header(alias=require_auth.header_name)] = None,
+        x_tenant_id: Annotated[
+            str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
+        ] = None,
     ):
         if docling_serve_settings.api_key:
-            if api_key != docling_serve_settings.api_key:
+            # Prefer the API key from the header; fall back to the query
+            # parameter for browser clients that cannot set headers. Note that
+            # query-parameter keys may be captured in proxy/access logs.
+            provided_key = x_api_key if x_api_key is not None else api_key
+            if provided_key != docling_serve_settings.api_key:
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Api key is required as ?api_key=SECRET.",
+                    detail=(
+                        f"Api key is required as the {require_auth.header_name} "
+                        "header or ?api_key=SECRET query parameter."
+                    ),
                 )
+
+        tenant_id = _get_tenant_id_from_header(x_tenant_id)
 
         assert isinstance(orchestrator.notifier, WebsocketNotifier)
         await websocket.accept()
 
         try:
             task = await orchestrator.task_status(task_id=task_id)
+            _assert_task_tenant(task, tenant_id)
         except RedisBackpressureError:
             await websocket.send_text(
                 WebsocketMessage(
@@ -1405,8 +1445,14 @@ def create_app():  # noqa: C901
         orchestrator: Annotated[BaseOrchestrator, Depends(get_async_orchestrator)],
         background_tasks: BackgroundTasks,
         task_id: str,
+        x_tenant_id: Annotated[
+            str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
+        ] = None,
     ):
+        tenant_id = _get_tenant_id_from_header(x_tenant_id)
         try:
+            task = await orchestrator.task_status(task_id=task_id)
+            _assert_task_tenant(task, tenant_id)
             outcome = await orchestrator.task_outcome(task_id=task_id)
             if outcome is None:
                 raise HTTPException(


### PR DESCRIPTION
### Problem
Authentication is a single shared API key for the whole service, and tenant identity is just the `X-Tenant-Id` header taken at face value. The task **read** endpoints (`status/poll`, `status/ws`, `result`) fetched tasks by UUID without ever checking that the caller's tenant matched the task's owner. Any key holder who learned a task UUID could fetch another tenant's converted documents and status. The websocket handler also only accepted the API key as a `?api_key=` query parameter, which lands in proxy/access logs.

### Changes
All in `docling_serve/app.py`:

- **New helpers** `_task_tenant_id()` / `_assert_task_tenant()`. The task's owner is read from `metadata["tenant_id"]` (already populated at enqueue time) and compared to the caller's resolved tenant. On mismatch it raises `TaskNotFoundError` → **404, not 403**, so a caller cannot probe whether a given UUID exists in another tenant.
- **`status/poll`, `status/ws`, `result`** now read the tenant header and call `_assert_task_tenant` before returning any task data. For `result`, the task is fetched via `task_status` first (the stored outcome carries no tenant), then the outcome.
- **Websocket auth hardening**: the handler now also accepts the key via the `X-Api-Key` **header** and prefers it over the query parameter (kept as a fallback for browser clients that can't set headers), with a comment noting the query form can leak into logs.

### Behavior when not using tenants
Fully transparent. With no header injected, every task is owned by `"default"` and every caller resolves to `"default"`, so the ownership check always passes. The check only ever triggers on a genuine create/read tenant mismatch — i.e. the bug. No config flag was added; this is now standard, unconditional behavior.

### Performance note (Ray/Redis)
- `status/poll` and `status/ws`: **no new Redis traffic** — they already fetched `task_status`; the ownership check reads in-memory `task.metadata`.
- `result`: **one additional Redis read per call** (`task_status` → `_task_from_redis` → `get_task_metadata_model`) before fetching the outcome, since the stored outcome doesn't carry tenant info. The result endpoint is terminal/low-frequency (typically once per task), so the extra keyed metadata read is negligible. This read also returns the authoritative durable `tenant_id`, so the check reflects current state.