### PR TITLE
feat: Add settings for coordinator and converter max_replicas_per_node

### DIFF
--- a/docling_serve/orchestrator_factory.py
+++ b/docling_serve/orchestrator_factory.py
@@ -292,6 +292,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             max_actors=docling_serve_settings.eng_ray_max_actors,
             target_requests_per_replica=docling_serve_settings.eng_ray_target_requests_per_replica,
             max_ongoing_requests_per_replica=docling_serve_settings.eng_ray_max_ongoing_requests_per_replica,
+            converter_max_replicas_per_node=docling_serve_settings.eng_ray_converter_max_replicas_per_node,
             upscale_delay_s=docling_serve_settings.eng_ray_upscale_delay_s,
             downscale_delay_s=docling_serve_settings.eng_ray_downscale_delay_s,
             graceful_shutdown_wait_loop_s=docling_serve_settings.eng_ray_graceful_shutdown_wait_loop_s,
@@ -304,6 +305,7 @@ def get_async_orchestrator() -> BaseOrchestrator:
             coordinator_max_actors=docling_serve_settings.eng_ray_coordinator_max_actors,
             coordinator_target_requests_per_replica=docling_serve_settings.eng_ray_coordinator_target_requests_per_replica,
             coordinator_max_ongoing_requests_per_replica=docling_serve_settings.eng_ray_coordinator_max_ongoing_requests_per_replica,
+            coordinator_max_replicas_per_node=docling_serve_settings.eng_ray_coordinator_max_replicas_per_node,
             coordinator_actor_num_cpus=docling_serve_settings.eng_ray_coordinator_actor_num_cpus,
             coordinator_actor_memory_request=docling_serve_settings.eng_ray_coordinator_actor_memory_request,
             # Fault Tolerance & Retry

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -248,6 +248,8 @@ class DoclingServeSettings(BaseSettings):
     # Hard cap on concurrent in-flight requests per replica.
     # None -> follow eng_ray_target_requests_per_replica.
     eng_ray_max_ongoing_requests_per_replica: Optional[int] = None
+    # Hard cap on converter Serve replicas per Ray node. None -> no cap.
+    eng_ray_converter_max_replicas_per_node: Optional[int] = None
     eng_ray_upscale_delay_s: float = 30.0
     eng_ray_downscale_delay_s: float = 600.0
     # None -> use Ray Serve defaults.
@@ -269,6 +271,8 @@ class DoclingServeSettings(BaseSettings):
     eng_ray_coordinator_max_actors: Optional[int] = None
     eng_ray_coordinator_target_requests_per_replica: Optional[int] = None
     eng_ray_coordinator_max_ongoing_requests_per_replica: int = 8
+    # Hard cap on coordinator Serve replicas per Ray node. None -> no cap.
+    eng_ray_coordinator_max_replicas_per_node: Optional[int] = None
     eng_ray_coordinator_actor_num_cpus: float = 0.25
     eng_ray_coordinator_actor_memory_request: Optional[str] = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,7 @@ triton-rocm = [
 ]
 
 # docling-slim = { git = "https://github.com/docling-project/docling/", rev = "main" }
-docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "cau/coordinator-placement" }
+docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "main" }
 # docling-jobkit = { path = "../docling-jobkit", editable = true }
 
 [[tool.uv.index]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,7 @@ triton-rocm = [
 ]
 
 # docling-slim = { git = "https://github.com/docling-project/docling/", rev = "main" }
-# docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "main" }
+docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "cau/coordinator-placement" }
 # docling-jobkit = { path = "../docling-jobkit", editable = true }
 
 [[tool.uv.index]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,7 @@ triton-rocm = [
 ]
 
 # docling-slim = { git = "https://github.com/docling-project/docling/", rev = "main" }
-docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "main" }
+# docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "main" }
 # docling-jobkit = { path = "../docling-jobkit", editable = true }
 
 [[tool.uv.index]]


### PR DESCRIPTION
## Summary

Surfaces the new per-node replica cap from docling-jobkit as docling-serve settings, so operators can control coordinator/converter placement across Ray nodes.

## Changes

- **`docling_serve/settings.py`.** Added `eng_ray_converter_max_replicas_per_node` and `eng_ray_coordinator_max_replicas_per_node` (`Optional[int]`, default `None`).
- **`docling_serve/orchestrator_factory.py`.** Mapped both settings onto the corresponding `RayOrchestratorConfig` fields (`converter_max_replicas_per_node`, `coordinator_max_replicas_per_node`).

## Behavior

Default is `None` for both, i.e. no cap and no change to existing deployments. Setting `eng_ray_coordinator_max_replicas_per_node=1` spreads coordinators one per Ray node; the converter cap is typically left unset so Ray packs converters for density.

## Dependency
see https://github.com/docling-project/docling-jobkit/pull/173