### PR TITLE
feat: surface confidence on convert response

### DIFF
--- a/docling_serve/response_preparation.py
+++ b/docling_serve/response_preparation.py
@@ -39,6 +39,7 @@ async def prepare_response(
             processing_time=task_result.processing_time,
             timings=task_result.result.timings,
             errors=task_result.result.errors,
+            confidence=task_result.result.confidence,
         )
     elif isinstance(task_result.result, ZipArchiveResult):
         response = Response(

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,7 +13,7 @@ On top of the source of file (see below), both endpoints support the same parame
 |------------|------|-------------|
 | `from_formats` | List[InputFormat] | Input format(s) to convert from. String or list of strings. Allowed values: `docx`, `pptx`, `html`, `image`, `pdf`, `asciidoc`, `md`, `csv`, `xlsx`, `xml_uspto`, `xml_jats`, `xml_xbrl`, `xml_doclang`, `mets_gbs`, `json_docling`, `audio`, `vtt`, `latex`, `email`, `epub`. Optional, defaults to all formats. |
 | `to_formats` | List[OutputFormat] | Output format(s) to convert to. String or list of strings. Allowed values: `md`, `json`, `yaml`, `html`, `html_split_page`, `text`, `doctags`, `vtt`, `doclang`. Optional, defaults to Markdown. |
-| `image_export_mode` | ImageRefMode | Image export mode for the document (in case of JSON, Markdown or HTML). Allowed values: `placeholder`, `embedded`, `referenced`. Optional, defaults to Embedded. |
+| `image_export_mode` | ImageRefMode | Image export mode for the document (in case of JSON, Markdown or HTML). Allowed values: `placeholder`, `embedded`, `referenced`. Optional, defaults to Placeholder. |
 | `do_ocr` | bool | If enabled, the bitmap content will be processed using OCR. Boolean. Optional, defaults to true |
 | `force_ocr` | bool | If enabled, replace existing text with OCR-generated text over content. Boolean. Optional, defaults to false. |
 | `ocr_engine` | str | DEPRECATED: Use ocr_preset instead. The OCR engine to use. String.  |
@@ -82,6 +82,7 @@ On top of the source of file (see below), both endpoints support the same parame
 | `trust_remote_code` | bool | Whether to trust remote code for this model |
 | `stop_strings` | List[str] | Stop strings for generation |
 | `max_new_tokens` | int | Maximum number of new tokens to generate |
+| `temperature` | float | Sampling temperature for generation. 0.0 uses greedy decoding. |
 
 <h4>BaseVlmEngineOptions</h4>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "docling-slim[standard,service-client,remote-serving]>=2.101.2,<3.0.0",
+    "docling-slim[standard,service-client,models-remote]>=2.101.2,<3.0.0",
     "docling-core>=2.79.0",
     "docling-jobkit[rq,ray,vlm]>=1.23.1,<2.0.0",
     "fastapi[standard]<0.137.0",
@@ -193,7 +193,7 @@ triton-rocm = [
     { index = "pytorch-rocm72", group = "rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" }
 ]
 
-# docling-slim = { git = "https://github.com/docling-project/docling/", rev = "main" }
+docling-slim = { git = "https://github.com/docling-project/docling/", rev = "cau/expose-confidence-through-service" }
 # docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "main" }
 # docling-jobkit = { path = "../docling-jobkit", editable = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "docling-slim[standard,service-client,models-remote]>=2.101.2,<3.0.0",
+    "docling-slim[standard,service-client,models-remote]>=2.104.0,<3.0.0",
     "docling-core>=2.79.0",
     "docling-jobkit[rq,ray,vlm]>=1.23.1,<2.0.0",
     "fastapi[standard]<0.137.0",
@@ -193,7 +193,7 @@ triton-rocm = [
     { index = "pytorch-rocm72", group = "rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" }
 ]
 
-docling-slim = { git = "https://github.com/docling-project/docling/", rev = "cau/expose-confidence-through-service" }
+# docling-slim = { git = "https://github.com/docling-project/docling/", rev = "main" }
 # docling-jobkit = { git = "https://github.com/docling-project/docling-jobkit/", rev = "main" }
 # docling-jobkit = { path = "../docling-jobkit", editable = true }
 


### PR DESCRIPTION
Forward document-level confidence onto ConvertDocumentResponse in prepare_response. The presigned path needs no change — it already returns per-document items, which now carry confidence.

Includes `uv lock --upgrade` as below:
```
Updated anyio v4.13.0 -> v4.14.0
Updated boto3 v1.43.28 -> v1.43.34
Updated botocore v1.43.28 -> v1.43.34
Updated certifi v2026.5.20 -> v2026.6.17
Updated cryptography v48.0.1 -> v49.0.0
Updated docling-core v2.82.0 -> v2.83.1
Updated docling-slim v2.104.0 -> v2.105.0
Updated fastapi-cli v0.0.24 -> v0.0.27
Updated filelock v3.29.3 -> v3.29.4
Updated google-auth v2.53.0 -> v2.55.0
Updated gradio v6.18.0 -> v6.19.0
Updated huggingface-hub v1.19.0 -> v1.20.1
Updated mcp v1.27.2 -> v1.28.0
Updated msgpack v1.2.0 -> v1.2.1
Updated nh3 v0.3.5 -> v0.3.6
Updated numpy v2.2.6, v2.4.6 -> v2.2.6, v2.4.6, v2.5.0
Updated onnxruntime v1.24.3, v1.26.0 -> v1.24.3, v1.27.0
Updated pre-commit-uv v4.2.1 -> v4.2.2
Updated pydantic-settings v2.14.1 -> v2.14.2
Updated pypdf v6.13.2 -> v6.13.3
Updated pypdfium2 v5.9.0 -> v5.10.1
Updated rapidocr v3.8.3 -> v3.8.4
Updated rq v2.9.1 -> v2.10.0
Updated ruff v0.15.17 -> v0.15.18
Updated s3transfer v0.18.0 -> v0.19.0
Updated scipy v1.15.3, v1.17.1 -> v1.15.3, v1.17.1, v1.18.0
Updated sentry-sdk v2.62.0 -> v2.63.0
Updated sse-starlette v3.4.4 -> v3.4.5
Updated torch v2.9.1+rocm6.3, v2.11.0+cu128, v2.12.0, v2.12.0+cpu, v2.12.0+cu126, v2.12.0+cu130, v2.12.0+rocm7.2 -> v2.9.1+rocm6.3, v2.11.0+cu128, v2.12.1, v2.12.1+cpu, v2.12.1+cu126, v2.12.1+cu130, v2.12.1+rocm7.2
Updated torchvision v0.24.1+rocm6.3, v0.26.0+cu128, v0.27.0, v0.27.0+cpu, v0.27.0+cu126, v0.27.0+cu130, v0.27.0+rocm7.2 -> v0.24.1+rocm6.3, v0.26.0+cu128, v0.27.1, v0.27.1+cu126, v0.27.1+cu130, v0.27.1+df56172, v0.27.1+rocm7.2
Updated tqdm v4.68.2 -> v4.68.3
Updated triton v3.6.0, v3.7.0 -> v3.6.0, v3.7.1
Updated triton-rocm v3.7.0 -> v3.7.1
Updated typer v0.21.2 -> v0.24.2
Updated uv v0.11.21 -> v0.11.23
Updated virtualenv v21.4.3 -> v21.5.1
```

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
