### PR TITLE
fix(metrics): expose Ray task-lifecycle counters

### DIFF
--- a/docling_serve/ray_metrics_collector.py
+++ b/docling_serve/ray_metrics_collector.py
@@ -1,5 +1,44 @@
 """Prometheus metrics collector for Ray orchestrator."""
 
+# Example Grafana / PromQL queries for the metrics exposed here. Replace `acme`
+# with a tenant_id, or drop the {tenant_id=...} selector and wrap in sum() to
+# aggregate across all tenants. Use rate()/increase() only on the *_total
+# counters, never on the *_pending / *_active gauges.
+#
+# --- Documents for a tenant ---
+#   # lifetime documents processed / succeeded / failed (cumulative counters)
+#   ray_tenant_documents_total{tenant_id="acme"}
+#   ray_tenant_documents_succeeded_total{tenant_id="acme"}
+#   ray_tenant_documents_failed_total{tenant_id="acme"}
+#   # documents processed in the last hour
+#   increase(ray_tenant_documents_total{tenant_id="acme"}[1h])
+#
+# --- Tasks for a tenant ---
+#   # current snapshot (gauges)
+#   ray_tenant_tasks_pending{tenant_id="acme"}   # waiting in queue
+#   ray_tenant_tasks_active{tenant_id="acme"}     # dispatched or running
+#   # currently running, derived from loss-proof counters
+#   ray_tenant_tasks_started_total{tenant_id="acme"}
+#     - ray_tenant_tasks_succeeded_total{tenant_id="acme"}
+#     - ray_tenant_tasks_failed_total{tenant_id="acme"}
+#   # lifetime totals
+#   ray_tenant_tasks_enqueued_total{tenant_id="acme"}
+#   ray_tenant_tasks_succeeded_total{tenant_id="acme"}
+#   ray_tenant_tasks_failed_total{tenant_id="acme"}
+#
+# --- Processing rate (derived) ---
+#   # documents/sec (multiply by 60 for /min); window must span >= 2 scrapes
+#   rate(ray_tenant_documents_total{tenant_id="acme"}[5m])
+#   # task completion rate (succeeded + failed), per second
+#   rate(ray_tenant_tasks_succeeded_total{tenant_id="acme"}[5m])
+#     + rate(ray_tenant_tasks_failed_total{tenant_id="acme"}[5m])
+#   # throughput across all tenants
+#   sum(rate(ray_tenant_documents_succeeded_total[5m]))
+#   # failure ratio (0-1)
+#   rate(ray_tenant_tasks_failed_total{tenant_id="acme"}[5m])
+#     / (rate(ray_tenant_tasks_succeeded_total{tenant_id="acme"}[5m])
+#        + rate(ray_tenant_tasks_failed_total{tenant_id="acme"}[5m]))
+
 import asyncio
 import concurrent.futures
 import logging

--- a/docling_serve/ray_metrics_collector.py
+++ b/docling_serve/ray_metrics_collector.py
@@ -3,6 +3,7 @@
 import asyncio
 import concurrent.futures
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from prometheus_client import Summary
@@ -11,35 +12,112 @@ from prometheus_client.registry import Collector
 
 logger = logging.getLogger(__name__)
 
-# Thread pool for running async operations from sync context
-# This avoids event loop conflicts by isolating async operations in a separate thread
+# Thread pool for running async operations from sync context. The Prometheus
+# Collector.collect() API is synchronous, but the Redis client is async; we run
+# the whole collection as a single coroutine in a dedicated thread/event loop to
+# avoid "Future attached to a different loop" errors.
 _executor = concurrent.futures.ThreadPoolExecutor(
     max_workers=1, thread_name_prefix="ray_metrics"
 )
 
+# Number of Redis reads issued per tenant in _collect_from_manager (counters,
+# stats, queue size, active count, limits). Used to size concurrency so the
+# in-flight reads stay within the connection pool.
+_READS_PER_TENANT = 5
 
-def run_async_with_new_connection(redis_manager, coro_func, *args, **kwargs) -> Any:
-    """Run async coroutine with a fresh Redis connection in a separate thread.
+# Hard ceiling for the timeout of a single scrape's Redis work.
+_COLLECT_TIMEOUT_S = 30
 
-    This creates a new RedisStateManager connection in the thread's event loop,
-    avoiding "Future attached to a different loop" errors that occur when using
-    a connection created in a different event loop.
 
-    Args:
-        redis_manager: Original RedisStateManager (used for config only)
-        coro_func: Async function to call (e.g., redis_manager.get_all_tenants_with_tasks)
-        *args: Arguments to pass to coro_func
-        **kwargs: Keyword arguments to pass to coro_func
+@dataclass
+class TenantSnapshot:
+    """All per-tenant values read from Redis in a single scrape."""
 
-    Returns:
-        Result of the coroutine
+    tenant_id: str
+    counters: Any  # TenantTaskCounters
+    stats: Any  # TenantStats
+    queue_size: int
+    active_count: int
+    limits: Any  # TenantLimits
+
+
+@dataclass
+class CollectedData:
+    """Everything one scrape needs, gathered over a single Redis connection."""
+
+    tenants: list  # list[TenantSnapshot]
+    num_tenants_with_any: int
+
+
+async def _collect_from_manager(redis_manager) -> CollectedData:
+    """Gather every metric value over a single (already connected) manager.
+
+    The two tenant-list reads run concurrently; then each tenant's reads run
+    concurrently, with a semaphore bounding the total in-flight reads to stay
+    within the connection pool. This replaces the previous design that opened
+    and tore down a fresh connection for every single value.
+    """
+    tenants_with_any, tenants_with_counters = await asyncio.gather(
+        redis_manager.get_all_tenants_with_any_tasks(),
+        redis_manager.get_all_tenants_with_task_counters(),
+    )
+    # Union: idle-but-historically-active tenants must keep being scraped,
+    # otherwise their counters would vanish and reappear, looking like a reset
+    # to rate()/increase().
+    tenants = sorted(set(tenants_with_any) | set(tenants_with_counters))
+
+    max_conn = getattr(redis_manager, "max_connections", None) or 50
+    # Leave a little headroom under the pool size; never below 1.
+    tenant_concurrency = max(1, min(16, (max_conn - 1) // _READS_PER_TENANT))
+    semaphore = asyncio.Semaphore(tenant_concurrency)
+
+    async def _one(tenant_id: str) -> TenantSnapshot:
+        async with semaphore:
+            counters, stats, queue_size, active_count, limits = await asyncio.gather(
+                redis_manager.get_tenant_task_counters(tenant_id),
+                redis_manager.get_tenant_stats(tenant_id),
+                redis_manager.get_tenant_queue_size(tenant_id),
+                redis_manager.get_tenant_active_task_count(tenant_id),
+                redis_manager.get_tenant_limits(tenant_id),
+            )
+            return TenantSnapshot(
+                tenant_id=tenant_id,
+                counters=counters,
+                stats=stats,
+                queue_size=queue_size,
+                active_count=active_count,
+                limits=limits,
+            )
+
+    results = await asyncio.gather(*(_one(t) for t in tenants), return_exceptions=True)
+
+    snapshots: list = []
+    for tenant_id, result in zip(tenants, results):
+        if isinstance(result, Exception):
+            logger.error(
+                "Error collecting metrics for tenant %s: %s",
+                tenant_id,
+                result,
+                exc_info=result,
+            )
+            continue
+        snapshots.append(result)
+
+    return CollectedData(tenants=snapshots, num_tenants_with_any=len(tenants_with_any))
+
+
+def collect_metrics_data(redis_manager) -> CollectedData:
+    """Run one full collection in a dedicated thread over a single connection.
+
+    Creates a fresh RedisStateManager in the thread's event loop (using the
+    original manager only for config), connects once, gathers all values, and
+    disconnects once.
 
     Raises:
-        TimeoutError: If coroutine takes longer than 30 seconds
+        TimeoutError: if the collection takes longer than _COLLECT_TIMEOUT_S.
     """
 
-    def run_in_thread():
-        """Run coroutine in a new event loop with fresh Redis connection."""
+    def run_in_thread() -> CollectedData:
         from docling_jobkit.orchestrators.ray.redis_helper import (
             RedisStateManager,
         )
@@ -47,7 +125,6 @@ def run_async_with_new_connection(redis_manager, coro_func, *args, **kwargs) -> 
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         try:
-            # Create a new RedisStateManager in this thread's event loop
             thread_redis_manager = RedisStateManager(
                 redis_url=redis_manager.redis_url,
                 results_ttl=redis_manager.results_ttl,
@@ -62,26 +139,22 @@ def run_async_with_new_connection(redis_manager, coro_func, *args, **kwargs) -> 
                 log_level=redis_manager.log_level,
             )
 
-            async def run_with_connection():
-                """Connect, run the coroutine, and disconnect."""
+            async def runner() -> CollectedData:
                 await thread_redis_manager.connect()
                 try:
-                    # Get the method from the new manager and call it
-                    method = getattr(thread_redis_manager, coro_func.__name__)
-                    return await method(*args, **kwargs)
+                    return await _collect_from_manager(thread_redis_manager)
                 finally:
                     await thread_redis_manager.disconnect()
 
-            return loop.run_until_complete(run_with_connection())
+            return loop.run_until_complete(runner())
         finally:
             loop.close()
 
-    # Submit to thread pool and wait for result with timeout
     future = _executor.submit(run_in_thread)
     try:
-        return future.result(timeout=30)  # 30 second timeout
+        return future.result(timeout=_COLLECT_TIMEOUT_S)
     except concurrent.futures.TimeoutError:
-        logger.error("Timeout waiting for async operation in metrics collector")
+        logger.error("Timeout collecting Ray metrics from Redis")
         raise
 
 
@@ -158,6 +231,9 @@ class RayCollector(Collector):
         - Per-tenant active documents
         - Per-tenant limits (concurrent tasks, queued tasks, documents)
         - System-wide totals and number of tenants with tasks
+
+        All values are read over a single Redis connection per scrape (see
+        collect_metrics_data), so scrape cost stays low even with many tenants.
         """
         logger.debug("Collecting Ray metrics...")
 
@@ -225,107 +301,60 @@ class RayCollector(Collector):
             )
 
             try:
-                # Union of tenants with live tasks and tenants with cumulative
-                # counters. Idle-but-historically-active tenants must keep being
-                # scraped, otherwise their counters would vanish and reappear,
-                # looking like a reset to rate()/increase().
-                tenants_with_any = run_async_with_new_connection(
-                    self.redis_manager,
-                    self.redis_manager.get_all_tenants_with_any_tasks,
-                )
-                tenants_with_counters = run_async_with_new_connection(
-                    self.redis_manager,
-                    self.redis_manager.get_all_tenants_with_task_counters,
-                )
-                tenants = sorted(set(tenants_with_any) | set(tenants_with_counters))
+                data = collect_metrics_data(self.redis_manager)
 
-                # Accumulators for snapshot totals
                 total_pending = 0
                 total_active = 0
                 total_docs = 0
 
-                # Collect per-tenant metrics
-                for tenant_id in tenants:
-                    try:
-                        # Monotonic counters
-                        counters = run_async_with_new_connection(
-                            self.redis_manager,
-                            self.redis_manager.get_tenant_task_counters,
-                            tenant_id,
-                        )
-                        for field, family in counter_families.items():
-                            family.add_metric([tenant_id], getattr(counters, field))
+                for snap in data.tenants:
+                    tenant_id = snap.tenant_id
 
-                        # Cumulative document counters (best-effort, from stats)
-                        stats = run_async_with_new_connection(
-                            self.redis_manager,
-                            self.redis_manager.get_tenant_stats,
-                            tenant_id,
-                        )
-                        for attr, family in stats_counter_families.items():
-                            family.add_metric([tenant_id], getattr(stats, attr))
+                    # Monotonic lifecycle counters
+                    for field, family in counter_families.items():
+                        family.add_metric([tenant_id], getattr(snap.counters, field))
 
-                        # Queue depth (pending tasks) - O(1) LLEN
-                        queue_size = run_async_with_new_connection(
-                            self.redis_manager,
-                            self.redis_manager.get_tenant_queue_size,
-                            tenant_id,
-                        )
-                        tenant_tasks_pending.add_metric([tenant_id], queue_size)
-                        total_pending += queue_size
+                    # Cumulative document counters (best-effort, from stats)
+                    for attr, family in stats_counter_families.items():
+                        family.add_metric([tenant_id], getattr(snap.stats, attr))
 
-                        # Active tasks (dispatched or running) - O(1) SCARD
-                        active_count = run_async_with_new_connection(
-                            self.redis_manager,
-                            self.redis_manager.get_tenant_active_task_count,
-                            tenant_id,
-                        )
-                        tenant_tasks_active.add_metric([tenant_id], active_count)
-                        total_active += active_count
+                    # Queue depth (pending tasks)
+                    tenant_tasks_pending.add_metric([tenant_id], snap.queue_size)
+                    total_pending += snap.queue_size
 
-                        # Tenant limits (includes active documents)
-                        limits = run_async_with_new_connection(
-                            self.redis_manager,
-                            self.redis_manager.get_tenant_limits,
-                            tenant_id,
-                        )
+                    # Active tasks (dispatched or running)
+                    tenant_tasks_active.add_metric([tenant_id], snap.active_count)
+                    total_active += snap.active_count
 
-                        tenant_documents_active.add_metric(
-                            [tenant_id], limits.active_documents
-                        )
-                        total_docs += limits.active_documents
+                    # Active documents (from limits)
+                    limits = snap.limits
+                    tenant_documents_active.add_metric(
+                        [tenant_id], limits.active_documents
+                    )
+                    total_docs += limits.active_documents
 
-                        tenant_limit_max_concurrent.add_metric(
-                            [tenant_id], limits.max_concurrent_tasks
-                        )
+                    tenant_limit_max_concurrent.add_metric(
+                        [tenant_id], limits.max_concurrent_tasks
+                    )
 
-                        # Handle None values for optional limits (0 = unlimited)
-                        max_queued = (
-                            limits.max_queued_tasks
-                            if limits.max_queued_tasks is not None
-                            else 0
-                        )
-                        tenant_limit_max_queued.add_metric([tenant_id], max_queued)
+                    # Handle None values for optional limits (0 = unlimited)
+                    max_queued = (
+                        limits.max_queued_tasks
+                        if limits.max_queued_tasks is not None
+                        else 0
+                    )
+                    tenant_limit_max_queued.add_metric([tenant_id], max_queued)
 
-                        max_docs = (
-                            limits.max_documents
-                            if limits.max_documents is not None
-                            else 0
-                        )
-                        tenant_limit_max_documents.add_metric([tenant_id], max_docs)
-
-                    except Exception as e:
-                        logger.error(
-                            f"Error collecting metrics for tenant {tenant_id}: {e}",
-                            exc_info=True,
-                        )
-                        continue
+                    max_docs = (
+                        limits.max_documents if limits.max_documents is not None else 0
+                    )
+                    tenant_limit_max_documents.add_metric([tenant_id], max_docs)
 
                 # Set total snapshot gauges
                 total_tasks_pending.add_metric([], total_pending)
                 total_tasks_active.add_metric([], total_active)
                 total_documents_active.add_metric([], total_docs)
-                tenants_with_tasks.add_metric([], len(tenants_with_any))
+                tenants_with_tasks.add_metric([], data.num_tenants_with_any)
 
             except Exception as e:
                 logger.error(f"Error collecting Fair Ray metrics: {e}", exc_info=True)

--- a/docling_serve/ray_metrics_collector.py
+++ b/docling_serve/ray_metrics_collector.py
@@ -98,6 +98,23 @@ _LIFECYCLE_COUNTERS = [
     ("ray_tenant_tasks_failed", "tasks_failed_total", "Tasks failed"),
 ]
 
+# Per-tenant cumulative document counters, read from the tenant:{id}:stats hash
+# (TenantStats). Tuple is (prometheus_name, stats_attr, help). These are
+# best-effort: stats is written as a post-finalize follow-up, and only
+# documents_succeeded / documents_failed reflect the real per-document counts
+# from the conversion result. total_documents (and failure-path failed counts)
+# fall back to the task's source-spec count, which is not the document count for
+# expanding sources such as S3 buckets. Exposed as-is for now.
+_STATS_COUNTERS = [
+    ("ray_tenant_documents", "total_documents", "Documents processed (terminal)"),
+    (
+        "ray_tenant_documents_succeeded",
+        "successful_documents",
+        "Documents successfully converted (terminal)",
+    ),
+    ("ray_tenant_documents_failed", "failed_documents", "Documents failed (terminal)"),
+]
+
 
 class RayCollector(Collector):
     """Ray orchestrator metrics collector for Prometheus.
@@ -131,6 +148,10 @@ class RayCollector(Collector):
         e.g. currently-running =
         tasks_started_total - tasks_succeeded_total - tasks_failed_total.
 
+        Plus cumulative per-tenant document counters from the stats hash
+        (documents processed / succeeded / failed); best-effort, see
+        _STATS_COUNTERS.
+
         Plus cheap O(1) snapshot gauges for current depth:
         - Per-tenant pending tasks (queue length)
         - Per-tenant active tasks (dispatched-or-running, active-set size)
@@ -145,6 +166,12 @@ class RayCollector(Collector):
             counter_families = {
                 field: CounterMetricFamily(name, doc, labels=["tenant_id"])
                 for name, field, doc in _LIFECYCLE_COUNTERS
+            }
+
+            # --- Cumulative document counters (per tenant, from stats) ---
+            stats_counter_families = {
+                attr: CounterMetricFamily(name, doc, labels=["tenant_id"])
+                for name, attr, doc in _STATS_COUNTERS
             }
 
             # --- Snapshot gauges (current depth) ---
@@ -229,6 +256,15 @@ class RayCollector(Collector):
                         for field, family in counter_families.items():
                             family.add_metric([tenant_id], getattr(counters, field))
 
+                        # Cumulative document counters (best-effort, from stats)
+                        stats = run_async_with_new_connection(
+                            self.redis_manager,
+                            self.redis_manager.get_tenant_stats,
+                            tenant_id,
+                        )
+                        for attr, family in stats_counter_families.items():
+                            family.add_metric([tenant_id], getattr(stats, attr))
+
                         # Queue depth (pending tasks) - O(1) LLEN
                         queue_size = run_async_with_new_connection(
                             self.redis_manager,
@@ -297,6 +333,7 @@ class RayCollector(Collector):
 
             # Yield all metrics
             yield from counter_families.values()
+            yield from stats_counter_families.values()
             yield tenant_tasks_pending
             yield tenant_tasks_active
             yield tenant_documents_active

--- a/docling_serve/ray_metrics_collector.py
+++ b/docling_serve/ray_metrics_collector.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from prometheus_client import Summary
-from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 from prometheus_client.registry import Collector
 
 logger = logging.getLogger(__name__)
@@ -85,45 +85,18 @@ def run_async_with_new_connection(redis_manager, coro_func, *args, **kwargs) -> 
         raise
 
 
-def get_tenant_activity_breakdown(redis_manager, tenant_id: str) -> tuple[int, int]:
-    """Classify active tenant tasks into dispatched vs running.
-
-    The current RedisStateManager no longer exposes direct per-tenant dispatched
-    and running counters, so derive them from active task metadata.
-    """
-    active_task_ids = run_async_with_new_connection(
-        redis_manager,
-        redis_manager.get_tenant_active_task_ids,
-        tenant_id,
-    )
-    dispatched_count = 0
-    running_count = 0
-
-    for task_id in active_task_ids:
-        metadata = run_async_with_new_connection(
-            redis_manager,
-            redis_manager.get_task_metadata,
-            task_id,
-        )
-        status = str(metadata.get("status", "")).upper()
-        if status == "STARTED":
-            running_count += 1
-            continue
-        if status == "PENDING":
-            dispatched_count += 1
-            continue
-
-        dispatch_state = run_async_with_new_connection(
-            redis_manager,
-            redis_manager.get_task_dispatch_hash,
-            task_id,
-        )
-        if dispatch_state.get("processing_started_at"):
-            running_count += 1
-        else:
-            dispatched_count += 1
-
-    return dispatched_count, running_count
+# Per-tenant monotonic lifecycle counters exposed to Prometheus. The name is the
+# Redis hash field; the Prometheus metric name is derived by stripping the
+# trailing "_total" (CounterMetricFamily re-appends it) and prefixing "ray_".
+# These are cumulative and read straight from Redis, so transitions that happen
+# between two scrapes are never lost.
+_LIFECYCLE_COUNTERS = [
+    ("ray_tenant_tasks_enqueued", "tasks_enqueued_total", "Tasks enqueued"),
+    ("ray_tenant_tasks_dispatched", "tasks_dispatched_total", "Tasks dispatched"),
+    ("ray_tenant_tasks_started", "tasks_started_total", "Tasks started"),
+    ("ray_tenant_tasks_succeeded", "tasks_succeeded_total", "Tasks succeeded"),
+    ("ray_tenant_tasks_failed", "tasks_failed_total", "Tasks failed"),
+]
 
 
 class RayCollector(Collector):
@@ -150,33 +123,39 @@ class RayCollector(Collector):
     def collect(self):
         """Collect Ray metrics from Redis.
 
-        Yields Prometheus metric families for:
-        - Per-tenant pending tasks
-        - Per-tenant running tasks
+        Yields Prometheus metric families:
+
+        Monotonic per-tenant lifecycle counters (cumulative, loss-proof across
+        scrapes) for the queued -> dispatched -> started -> terminal transitions.
+        Instantaneous occupancy is derived in Grafana from counter differences,
+        e.g. currently-running =
+        tasks_started_total - tasks_succeeded_total - tasks_failed_total.
+
+        Plus cheap O(1) snapshot gauges for current depth:
+        - Per-tenant pending tasks (queue length)
+        - Per-tenant active tasks (dispatched-or-running, active-set size)
         - Per-tenant active documents
         - Per-tenant limits (concurrent tasks, queued tasks, documents)
-        - Total pending tasks
-        - Total running tasks
-        - Total active documents
-        - Number of tenants with tasks
+        - System-wide totals and number of tenants with tasks
         """
         logger.debug("Collecting Ray metrics...")
 
         with self.summary.time():
-            # Define metric families
+            # --- Monotonic lifecycle counters (per tenant) ---
+            counter_families = {
+                field: CounterMetricFamily(name, doc, labels=["tenant_id"])
+                for name, field, doc in _LIFECYCLE_COUNTERS
+            }
+
+            # --- Snapshot gauges (current depth) ---
             tenant_tasks_pending = GaugeMetricFamily(
                 "ray_tenant_tasks_pending",
                 "Number of tasks waiting in tenant's queue (not yet dispatched to actors)",
                 labels=["tenant_id"],
             )
-            tenant_tasks_dispatched = GaugeMetricFamily(
-                "ray_tenant_tasks_dispatched",
-                "Number of tasks dispatched to actors but not yet started processing (status=PENDING)",
-                labels=["tenant_id"],
-            )
-            tenant_tasks_running = GaugeMetricFamily(
-                "ray_tenant_tasks_running",
-                "Number of tasks actively being processed (status=STARTED)",
+            tenant_tasks_active = GaugeMetricFamily(
+                "ray_tenant_tasks_active",
+                "Number of tasks currently in the active set (dispatched or running)",
                 labels=["tenant_id"],
             )
             tenant_documents_active = GaugeMetricFamily(
@@ -200,18 +179,14 @@ class RayCollector(Collector):
                 labels=["tenant_id"],
             )
 
-            # Total metrics (no labels)
+            # Total snapshot gauges (no labels)
             total_tasks_pending = GaugeMetricFamily(
                 "ray_total_tasks_pending",
                 "Total number of pending tasks across all tenants (in queue, not yet dispatched to actors)",
             )
-            total_tasks_dispatched = GaugeMetricFamily(
-                "ray_total_tasks_dispatched",
-                "Total number of dispatched tasks across all tenants (sent to actors but not yet started, status=PENDING)",
-            )
-            total_tasks_running = GaugeMetricFamily(
-                "ray_total_tasks_running",
-                "Total number of running tasks across all tenants (actively being processed, status=STARTED)",
+            total_tasks_active = GaugeMetricFamily(
+                "ray_total_tasks_active",
+                "Total number of active tasks across all tenants (dispatched or running)",
             )
             total_documents_active = GaugeMetricFamily(
                 "ray_total_documents_active",
@@ -223,22 +198,38 @@ class RayCollector(Collector):
             )
 
             try:
-                # Get all users with tasks (queued OR active) using a fresh connection
-                tenants = run_async_with_new_connection(
+                # Union of tenants with live tasks and tenants with cumulative
+                # counters. Idle-but-historically-active tenants must keep being
+                # scraped, otherwise their counters would vanish and reappear,
+                # looking like a reset to rate()/increase().
+                tenants_with_any = run_async_with_new_connection(
                     self.redis_manager,
                     self.redis_manager.get_all_tenants_with_any_tasks,
                 )
+                tenants_with_counters = run_async_with_new_connection(
+                    self.redis_manager,
+                    self.redis_manager.get_all_tenants_with_task_counters,
+                )
+                tenants = sorted(set(tenants_with_any) | set(tenants_with_counters))
 
-                # Accumulators for totals
+                # Accumulators for snapshot totals
                 total_pending = 0
-                total_dispatched = 0
-                total_running = 0
+                total_active = 0
                 total_docs = 0
 
-                # Collect per-user metrics
+                # Collect per-tenant metrics
                 for tenant_id in tenants:
                     try:
-                        # Get queue size (pending tasks)
+                        # Monotonic counters
+                        counters = run_async_with_new_connection(
+                            self.redis_manager,
+                            self.redis_manager.get_tenant_task_counters,
+                            tenant_id,
+                        )
+                        for field, family in counter_families.items():
+                            family.add_metric([tenant_id], getattr(counters, field))
+
+                        # Queue depth (pending tasks) - O(1) LLEN
                         queue_size = run_async_with_new_connection(
                             self.redis_manager,
                             self.redis_manager.get_tenant_queue_size,
@@ -247,38 +238,32 @@ class RayCollector(Collector):
                         tenant_tasks_pending.add_metric([tenant_id], queue_size)
                         total_pending += queue_size
 
-                        # Get dispatched task count (sent to actors but not yet running)
-                        dispatched_count, running_count = get_tenant_activity_breakdown(
-                            self.redis_manager, tenant_id
+                        # Active tasks (dispatched or running) - O(1) SCARD
+                        active_count = run_async_with_new_connection(
+                            self.redis_manager,
+                            self.redis_manager.get_tenant_active_task_count,
+                            tenant_id,
                         )
-                        tenant_tasks_dispatched.add_metric(
-                            [tenant_id], dispatched_count
-                        )
-                        total_dispatched += dispatched_count
+                        tenant_tasks_active.add_metric([tenant_id], active_count)
+                        total_active += active_count
 
-                        # Get running task count (actively being processed)
-                        tenant_tasks_running.add_metric([tenant_id], running_count)
-                        total_running += running_count
-
-                        # Get user limits (includes active documents)
+                        # Tenant limits (includes active documents)
                         limits = run_async_with_new_connection(
                             self.redis_manager,
                             self.redis_manager.get_tenant_limits,
                             tenant_id,
                         )
 
-                        # Active documents
                         tenant_documents_active.add_metric(
                             [tenant_id], limits.active_documents
                         )
                         total_docs += limits.active_documents
 
-                        # Tenant limits
                         tenant_limit_max_concurrent.add_metric(
                             [tenant_id], limits.max_concurrent_tasks
                         )
 
-                        # Handle None values for optional limits (use 0 to indicate unlimited)
+                        # Handle None values for optional limits (0 = unlimited)
                         max_queued = (
                             limits.max_queued_tasks
                             if limits.max_queued_tasks is not None
@@ -295,33 +280,31 @@ class RayCollector(Collector):
 
                     except Exception as e:
                         logger.error(
-                            f"Error collecting metrics for user {tenant_id}: {e}",
+                            f"Error collecting metrics for tenant {tenant_id}: {e}",
                             exc_info=True,
                         )
                         continue
 
-                # Set total metrics
+                # Set total snapshot gauges
                 total_tasks_pending.add_metric([], total_pending)
-                total_tasks_dispatched.add_metric([], total_dispatched)
-                total_tasks_running.add_metric([], total_running)
+                total_tasks_active.add_metric([], total_active)
                 total_documents_active.add_metric([], total_docs)
-                tenants_with_tasks.add_metric([], len(tenants))
+                tenants_with_tasks.add_metric([], len(tenants_with_any))
 
             except Exception as e:
                 logger.error(f"Error collecting Fair Ray metrics: {e}", exc_info=True)
                 # Return empty metrics on error
 
             # Yield all metrics
+            yield from counter_families.values()
             yield tenant_tasks_pending
-            yield tenant_tasks_dispatched
-            yield tenant_tasks_running
+            yield tenant_tasks_active
             yield tenant_documents_active
             yield tenant_limit_max_concurrent
             yield tenant_limit_max_queued
             yield tenant_limit_max_documents
             yield total_tasks_pending
-            yield total_tasks_dispatched
-            yield total_tasks_running
+            yield total_tasks_active
             yield total_documents_active
             yield tenants_with_tasks
 

--- a/tests/test_ray_metrics_collector.py
+++ b/tests/test_ray_metrics_collector.py
@@ -1,0 +1,118 @@
+"""Tests for the RayCollector Prometheus exposition.
+
+Verifies that the monotonic lifecycle counters are exposed (with the Prometheus
+``_total`` suffix), that a tenant which is idle but still has cumulative counters
+keeps being scraped, and that the snapshot gauges report current depth. The
+collector queries Redis via ``run_async_with_new_connection`` (a thread-pool that
+opens a fresh connection); here that helper is patched to call the mocked
+manager's method directly, keeping the test hermetic.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from prometheus_client import CollectorRegistry, generate_latest
+from prometheus_client.parser import text_string_to_metric_families
+
+from docling_jobkit.orchestrators.ray.models import TenantLimits, TenantTaskCounters
+
+from docling_serve.ray_metrics_collector import RayCollector
+
+
+def _sync_shim(redis_manager, coro_func, *args, **kwargs):
+    """Call the (mocked) manager method directly instead of in a thread."""
+    return coro_func(*args, **kwargs)
+
+
+def _make_manager():
+    manager = MagicMock()
+    manager.get_all_tenants_with_any_tasks = MagicMock(return_value=["tenant-a"])
+    # tenant-b is idle (no live tasks) but still carries cumulative counters.
+    manager.get_all_tenants_with_task_counters = MagicMock(
+        return_value=["tenant-a", "tenant-b"]
+    )
+
+    counters = {
+        "tenant-a": TenantTaskCounters(
+            tasks_enqueued_total=4,
+            tasks_dispatched_total=4,
+            tasks_started_total=4,
+            tasks_succeeded_total=3,
+            tasks_failed_total=1,
+        ),
+        "tenant-b": TenantTaskCounters(tasks_enqueued_total=7, tasks_succeeded_total=7),
+    }
+    queue_size = {"tenant-a": 2, "tenant-b": 0}
+    active = {"tenant-a": 1, "tenant-b": 0}
+
+    manager.get_tenant_task_counters = MagicMock(side_effect=lambda t: counters[t])
+    manager.get_tenant_queue_size = MagicMock(side_effect=lambda t: queue_size[t])
+    manager.get_tenant_active_task_count = MagicMock(side_effect=lambda t: active[t])
+    manager.get_tenant_limits = MagicMock(side_effect=lambda t: TenantLimits())
+    return manager
+
+
+# RayCollector.__init__ registers a Summary on the global registry, so it can
+# only be built once per process. Cache the collection result across tests.
+_CACHE: dict = {}
+
+
+def _collect_samples():
+    if _CACHE:
+        return _CACHE["samples"], _CACHE["text"]
+
+    manager = _make_manager()
+    registry = CollectorRegistry()
+    with patch(
+        "docling_serve.ray_metrics_collector.run_async_with_new_connection",
+        _sync_shim,
+    ):
+        registry.register(RayCollector(manager))
+        text = generate_latest(registry).decode("utf-8")
+
+    samples = {}
+    for family in text_string_to_metric_families(text):
+        for sample in family.samples:
+            key = (sample.name, tuple(sorted(sample.labels.items())))
+            samples[key] = sample.value
+    _CACHE["samples"] = samples
+    _CACHE["text"] = text
+    return samples, text
+
+
+def test_lifecycle_counters_exposed_with_total_suffix():
+    samples, _ = _collect_samples()
+
+    # CounterMetricFamily appends _total to the exposed sample name.
+    assert (
+        samples[("ray_tenant_tasks_enqueued_total", (("tenant_id", "tenant-a"),))] == 4
+    )
+    assert (
+        samples[("ray_tenant_tasks_succeeded_total", (("tenant_id", "tenant-a"),))] == 3
+    )
+    assert samples[("ray_tenant_tasks_failed_total", (("tenant_id", "tenant-a"),))] == 1
+
+
+def test_idle_tenant_with_counters_is_still_scraped():
+    samples, _ = _collect_samples()
+    # tenant-b has no live tasks but its cumulative counters must still appear,
+    # otherwise rate()/increase() would see a phantom counter reset.
+    assert (
+        samples[("ray_tenant_tasks_succeeded_total", (("tenant_id", "tenant-b"),))] == 7
+    )
+
+
+def test_snapshot_gauges_report_current_depth():
+    samples, _ = _collect_samples()
+    assert samples[("ray_tenant_tasks_pending", (("tenant_id", "tenant-a"),))] == 2
+    assert samples[("ray_tenant_tasks_active", (("tenant_id", "tenant-a"),))] == 1
+    # totals
+    assert samples[("ray_total_tasks_pending", ())] == 2
+    assert samples[("ray_total_tasks_active", ())] == 1
+
+
+def test_removed_lossy_metrics_are_gone():
+    _, text = _collect_samples()
+    # The old transient "running" gauge (and its total) lost data and is fully
+    # removed; "dispatched" now lives on as a monotonic counter instead.
+    assert "ray_tenant_tasks_running" not in text
+    assert "ray_total_tasks_running" not in text

--- a/tests/test_ray_metrics_collector.py
+++ b/tests/test_ray_metrics_collector.py
@@ -1,54 +1,70 @@
 """Tests for the RayCollector Prometheus exposition.
 
-Verifies that the monotonic lifecycle counters are exposed (with the Prometheus
-``_total`` suffix), that a tenant which is idle but still has cumulative counters
-keeps being scraped, and that the snapshot gauges report current depth. The
-collector queries Redis via ``run_async_with_new_connection`` (a thread-pool that
-opens a fresh connection); here that helper is patched to call the mocked
-manager's method directly, keeping the test hermetic.
+Verifies that the monotonic lifecycle counters and cumulative document counters
+are exposed (with the Prometheus ``_total`` suffix), that a tenant which is idle
+but still has cumulative counters keeps being scraped, and that the snapshot
+gauges report current depth. ``collect_metrics_data`` (which opens a single Redis
+connection per scrape) is patched to return canned data, keeping the exposition
+test hermetic; the gather logic itself is covered separately against an
+AsyncMock manager.
 """
 
-from unittest.mock import MagicMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from prometheus_client import CollectorRegistry, generate_latest
 from prometheus_client.parser import text_string_to_metric_families
 
-from docling_jobkit.orchestrators.ray.models import TenantLimits, TenantTaskCounters
+from docling_jobkit.orchestrators.ray.models import (
+    TenantLimits,
+    TenantStats,
+    TenantTaskCounters,
+)
 
-from docling_serve.ray_metrics_collector import RayCollector
+from docling_serve.ray_metrics_collector import (
+    CollectedData,
+    RayCollector,
+    TenantSnapshot,
+    _collect_from_manager,
+)
 
 
-def _sync_shim(redis_manager, coro_func, *args, **kwargs):
-    """Call the (mocked) manager method directly instead of in a thread."""
-    return coro_func(*args, **kwargs)
-
-
-def _make_manager():
-    manager = MagicMock()
-    manager.get_all_tenants_with_any_tasks = MagicMock(return_value=["tenant-a"])
-    # tenant-b is idle (no live tasks) but still carries cumulative counters.
-    manager.get_all_tenants_with_task_counters = MagicMock(
-        return_value=["tenant-a", "tenant-b"]
+def _canned_data() -> CollectedData:
+    return CollectedData(
+        tenants=[
+            TenantSnapshot(
+                tenant_id="tenant-a",
+                counters=TenantTaskCounters(
+                    tasks_enqueued_total=4,
+                    tasks_dispatched_total=4,
+                    tasks_started_total=4,
+                    tasks_succeeded_total=3,
+                    tasks_failed_total=1,
+                ),
+                stats=TenantStats(
+                    total_tasks=4,
+                    total_documents=10,
+                    successful_documents=8,
+                    failed_documents=2,
+                ),
+                queue_size=2,
+                active_count=1,
+                limits=TenantLimits(),
+            ),
+            # tenant-b is idle (no live tasks) but still carries counters.
+            TenantSnapshot(
+                tenant_id="tenant-b",
+                counters=TenantTaskCounters(
+                    tasks_enqueued_total=7, tasks_succeeded_total=7
+                ),
+                stats=TenantStats(),
+                queue_size=0,
+                active_count=0,
+                limits=TenantLimits(),
+            ),
+        ],
+        num_tenants_with_any=1,
     )
-
-    counters = {
-        "tenant-a": TenantTaskCounters(
-            tasks_enqueued_total=4,
-            tasks_dispatched_total=4,
-            tasks_started_total=4,
-            tasks_succeeded_total=3,
-            tasks_failed_total=1,
-        ),
-        "tenant-b": TenantTaskCounters(tasks_enqueued_total=7, tasks_succeeded_total=7),
-    }
-    queue_size = {"tenant-a": 2, "tenant-b": 0}
-    active = {"tenant-a": 1, "tenant-b": 0}
-
-    manager.get_tenant_task_counters = MagicMock(side_effect=lambda t: counters[t])
-    manager.get_tenant_queue_size = MagicMock(side_effect=lambda t: queue_size[t])
-    manager.get_tenant_active_task_count = MagicMock(side_effect=lambda t: active[t])
-    manager.get_tenant_limits = MagicMock(side_effect=lambda t: TenantLimits())
-    return manager
 
 
 # RayCollector.__init__ registers a Summary on the global registry, so it can
@@ -60,13 +76,12 @@ def _collect_samples():
     if _CACHE:
         return _CACHE["samples"], _CACHE["text"]
 
-    manager = _make_manager()
     registry = CollectorRegistry()
     with patch(
-        "docling_serve.ray_metrics_collector.run_async_with_new_connection",
-        _sync_shim,
+        "docling_serve.ray_metrics_collector.collect_metrics_data",
+        return_value=_canned_data(),
     ):
-        registry.register(RayCollector(manager))
+        registry.register(RayCollector(MagicMock()))
         text = generate_latest(registry).decode("utf-8")
 
     samples = {}
@@ -90,6 +105,20 @@ def test_lifecycle_counters_exposed_with_total_suffix():
         samples[("ray_tenant_tasks_succeeded_total", (("tenant_id", "tenant-a"),))] == 3
     )
     assert samples[("ray_tenant_tasks_failed_total", (("tenant_id", "tenant-a"),))] == 1
+
+
+def test_document_counters_exposed_from_stats():
+    samples, _ = _collect_samples()
+    # CounterMetricFamily appends _total; values come from the stats hash.
+    assert samples[("ray_tenant_documents_total", (("tenant_id", "tenant-a"),))] == 10
+    assert (
+        samples[("ray_tenant_documents_succeeded_total", (("tenant_id", "tenant-a"),))]
+        == 8
+    )
+    assert (
+        samples[("ray_tenant_documents_failed_total", (("tenant_id", "tenant-a"),))]
+        == 2
+    )
 
 
 def test_idle_tenant_with_counters_is_still_scraped():
@@ -116,3 +145,49 @@ def test_removed_lossy_metrics_are_gone():
     # removed; "dispatched" now lives on as a monotonic counter instead.
     assert "ray_tenant_tasks_running" not in text
     assert "ray_total_tasks_running" not in text
+
+
+def test_collect_from_manager_uses_single_manager_and_unions_tenants():
+    """The gather opens no per-call connections and scrapes the tenant union."""
+    manager = AsyncMock()
+    manager.max_connections = 50
+    manager.get_all_tenants_with_any_tasks.return_value = ["tenant-a"]
+    manager.get_all_tenants_with_task_counters.return_value = ["tenant-a", "tenant-b"]
+    manager.get_tenant_task_counters.side_effect = lambda t: TenantTaskCounters(
+        tasks_enqueued_total=1
+    )
+    manager.get_tenant_stats.side_effect = lambda t: TenantStats(total_documents=3)
+    manager.get_tenant_queue_size.side_effect = lambda t: 5
+    manager.get_tenant_active_task_count.side_effect = lambda t: 1
+    manager.get_tenant_limits.side_effect = lambda t: TenantLimits()
+
+    data = asyncio.run(_collect_from_manager(manager))
+
+    assert data.num_tenants_with_any == 1
+    assert {s.tenant_id for s in data.tenants} == {"tenant-a", "tenant-b"}
+    # connect/disconnect are owned by collect_metrics_data, not the gather.
+    manager.connect.assert_not_called()
+    manager.disconnect.assert_not_called()
+
+
+def test_collect_from_manager_skips_tenant_that_errors():
+    manager = AsyncMock()
+    manager.max_connections = 50
+    manager.get_all_tenants_with_any_tasks.return_value = ["good", "bad"]
+    manager.get_all_tenants_with_task_counters.return_value = []
+
+    def _counters(tenant_id):
+        if tenant_id == "bad":
+            raise RuntimeError("redis blew up")
+        return TenantTaskCounters(tasks_enqueued_total=1)
+
+    manager.get_tenant_task_counters.side_effect = _counters
+    manager.get_tenant_stats.side_effect = lambda t: TenantStats()
+    manager.get_tenant_queue_size.side_effect = lambda t: 0
+    manager.get_tenant_active_task_count.side_effect = lambda t: 0
+    manager.get_tenant_limits.side_effect = lambda t: TenantLimits()
+
+    data = asyncio.run(_collect_from_manager(manager))
+
+    # The failing tenant is dropped; the healthy one still reported.
+    assert {s.tenant_id for s in data.tenants} == {"good"}


### PR DESCRIPTION
## Description

Reworks `RayCollector` to expose the Ray orchestrator's task lifecycle as **monotonic Prometheus counters** instead of point-in-time gauges scanned from Redis at scrape time.

### Why

The old collector published only gauges computed by scanning Redis at scrape time. That loses data: any state transition that happens entirely between two Prometheus scrapes is never observed. In practice, submitting a few short tasks could show **nothing** in `ray_tenant_tasks_dispatched`, because:

- "dispatched" was a sub-second transient (a task's status flips to `STARTED` almost immediately), so the gauge was almost always 0;
- short tasks could pass `queued → running → done` between two scrapes and be completely invisible;
- the dispatched/running split relied on an N+1 per-task metadata scan and a dead fallback branch.

### What changed

- `RayCollector` now reads the per-tenant `task_counters` hash (via `get_tenant_task_counters`) and exposes cumulative `CounterMetricFamily` metrics with a `tenant_id` label:
  - `ray_tenant_tasks_enqueued_total`
  - `ray_tenant_tasks_dispatched_total`
  - `ray_tenant_tasks_started_total`
  - `ray_tenant_tasks_succeeded_total`
  - `ray_tenant_tasks_failed_total`
- Because these counters are cumulative and persist in Redis, they capture every transition regardless of scrape timing.
- Removed the lossy dispatched/running gauges, the expensive per-task `hgetall` scan, and the dead `processing_started_at` branch. Kept cheap O(1) snapshot gauges for current depth (`ray_tenant_tasks_pending` from queue length, `ray_tenant_tasks_active` from the active-set size), plus the existing limit/document gauges.
- The collector iterates the union of tenants-with-tasks and tenants-with-counters, so idle-but-historically-active tenants keep being scraped (a counter that disappears and reappears would look like a reset and corrupt `rate()`).

In Grafana, instantaneous occupancy is derived from counter differences, e.g. currently-running = `tasks_started_total - tasks_succeeded_total - tasks_failed_total`.

### Tests

`tests/test_ray_metrics_collector.py` verifies the counters are exposed as `ray_tenant_tasks_*_total` with the right `tenant_id` labels and values, and that activity is observed via counters even when the active-set snapshot gauge reads zero.

### Reviewer note

This depends on the **companion docling-jobkit PR** (docling-project/docling-jobkit#181), which introduces the `tenant:{id}:task_counters` hash, the atomic per-transition increments, and the `get_tenant_task_counters` / `get_all_tenants_with_task_counters` getters this collector calls. Merge/release that first.