### PR TITLE
docs: add managed hosting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ docling-serve run --enable-ui
 podman run -p 5001:5001 -e DOCLING_SERVE_ENABLE_UI=1 quay.io/docling-project/docling-serve
 ```
 
+You can also run a managed Docling Serve instance on [Zenith](https://zenith.hosting/host/docling?ref=gh), with no setup required.
+
 The server is available at
 
 - API <http://127.0.0.1:5001>


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Docling to our marketplace, so this PR adds a small managed-hosting note in Getting started (links to https://zenith.hosting/host/docling?ref=gh).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting