### PR TITLE
feat(rq): configurable HTTP source fetch retries

### DIFF
--- a/docling_serve/__main__.py
+++ b/docling_serve/__main__.py
@@ -429,6 +429,8 @@ def rq_worker() -> Any:
         redis_gate_reserved_connections=docling_serve_settings.eng_rq_redis_gate_reserved_connections,
         redis_gate_wait_timeout=docling_serve_settings.eng_rq_redis_gate_wait_timeout,
         redis_gate_status_poll_wait_timeout=docling_serve_settings.eng_rq_redis_gate_status_poll_wait_timeout,
+        max_task_retries=docling_serve_settings.eng_rq_max_task_retries,
+        retry_delay=docling_serve_settings.eng_rq_retry_delay,
         s3_presigned_config=_build_s3_presigned_config(),
     )
 

--- a/docling_serve/orchestrator_factory.py
+++ b/docling_serve/orchestrator_factory.py
@@ -145,6 +145,8 @@ def get_async_orchestrator() -> BaseOrchestrator:
             zombie_reaper_interval=docling_serve_settings.eng_rq_zombie_reaper_interval,
             zombie_reaper_max_age=docling_serve_settings.eng_rq_zombie_reaper_max_age,
             result_removal_delay=docling_serve_settings.result_removal_delay,
+            max_task_retries=docling_serve_settings.eng_rq_max_task_retries,
+            retry_delay=docling_serve_settings.eng_rq_retry_delay,
             s3_presigned_config=_build_s3_presigned_config(),
         )
 

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -199,6 +199,9 @@ class DoclingServeSettings(BaseSettings):
     eng_rq_redis_gate_status_poll_wait_timeout: float = 5.0
     eng_rq_zombie_reaper_interval: float = 300.0
     eng_rq_zombie_reaper_max_age: float = 3600.0
+    # HTTP source fetch retries (transient failures only)
+    eng_rq_max_task_retries: int = 3
+    eng_rq_retry_delay: float = 5.0
     # Fair Ray engine
     # Redis Configuration
     eng_ray_redis_url: str = ""

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -280,6 +280,8 @@ The following table describes the options to configure the Docling Serve RQ engi
 | `DOCLING_SERVE_ENG_RQ_REDIS_MAX_CONNECTIONS` | `50` | Maximum number of connections in the Redis connection pool. Increase this value when scaling to many RQ workers (e.g., 100 for 10+ workers). |
 | `DOCLING_SERVE_ENG_RQ_REDIS_SOCKET_TIMEOUT` | `None` | Socket timeout in seconds for Redis operations. If not set, uses Redis client default. Set to a value (e.g., 5.0) if you experience timeout issues. |
 | `DOCLING_SERVE_ENG_RQ_REDIS_SOCKET_CONNECT_TIMEOUT` | `None` | Socket connect timeout in seconds for establishing Redis connections. If not set, uses Redis client default. Set to a value (e.g., 5.0) for slow networks. |
+| `DOCLING_SERVE_ENG_RQ_MAX_TASK_RETRIES` | `3` | Number of additional attempts when fetching an HTTP source URL fails with a transient error (429, 502, 503, 504, or a connection/timeout failure). Permanent failures (401/403/404/413/415/422, oversize) are never retried. Set to `0` to disable retrying. |
+| `DOCLING_SERVE_ENG_RQ_RETRY_DELAY` | `5.0` | Fixed delay, in seconds, between HTTP source fetch retry attempts. |
 
 **Scaling Recommendations for RQ Engine:**
 


### PR DESCRIPTION
## Summary

This exposes two new settings for the RQ engine so operators can control how HTTP source fetches are retried, and wires them into `RQOrchestratorConfig`. It is the docling-serve half of the retry work; the behaviour itself lives in docling-project/docling-jobkit#200, and both follow up on #648.

The new settings mirror the existing `eng_ray_*` retry knobs, so the two engines are configured the same way.

## What this changes

Two new settings (defaults chosen to match the Ray engine):

| Environment variable | Default | Description |
| --- | --- | --- |
| `DOCLING_SERVE_ENG_RQ_MAX_TASK_RETRIES` | `3` | Additional attempts when fetching an HTTP source fails with a transient error (`429`, `502`, `503`, `504`, or a connection/timeout failure). Permanent failures (`401`/`403`/`404`/`413`/`415`/`422`, oversize) are never retried. Set to `0` to disable retrying. |
| `DOCLING_SERVE_ENG_RQ_RETRY_DELAY` | `5.0` | Fixed delay, in seconds, between HTTP source fetch retry attempts. |

They are wired into `RQOrchestratorConfig` at both construction sites — the API's `orchestrator_factory.py` and the `rq-worker` command in `__main__.py`. Both are needed: the fetch (and therefore the retry) happens in the worker process, so the worker's config is the one that actually governs retry behaviour.

### Files

- `docling_serve/settings.py` — `eng_rq_max_task_retries`, `eng_rq_retry_delay`.
- `docling_serve/orchestrator_factory.py` — pass them into `RQOrchestratorConfig` (API).
- `docling_serve/__main__.py` — pass them into `RQOrchestratorConfig` (`rq-worker`).
- `docs/configuration.md` — document the two variables.

## Consistency with the Ray engine

The names (`max_task_retries` / `retry_delay`), defaults (`3` / `5.0`) and settings style match the existing `eng_ray_max_task_retries` / `eng_ray_retry_delay`, so operators configure both engines the same way.

## Compatibility

`RQOrchestratorConfig` ignores unknown keyword arguments, so this change is safe to merge against the current released docling-jobkit — the new arguments are simply dropped until the jobkit change (docling-project/docling-jobkit#<jobkit-pr>) is released, at which point the retries take effect. Merging jobkit first is recommended so the settings are functional on release.

## Testing

Validated end-to-end by running the API and an `rq-worker` from this branch (with the docling-jobkit branch installed) against a live Redis. Setting the variables and submitting a task whose HTTP source returns `503` produced the configured behaviour in the worker log:

```
DOCLING_SERVE_ENG_RQ_MAX_TASK_RETRIES=2
DOCLING_SERVE_ENG_RQ_RETRY_DELAY=1
```

```
retry 1/2 after 1.0s
retry 2/2 after 1.0s
```

(With the defaults left in place the worker retries `3` times with a `5.0`s delay, as expected.)

## Related

- Original issue: #648
- docling-jobkit PR (the behaviour): docling-project/docling-jobkit#200
