### PR TITLE
feat: add allowed_source_types policy control

### DIFF
--- a/docling_serve/policy.py
+++ b/docling_serve/policy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
@@ -9,8 +10,10 @@ from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.datamodel.service.requests import (
     BaseChunkDocumentsRequest,
     BatchConvertSourcesRequest,
+    BatchSourceRequestItem,
     ConvertSourcesRequest,
     S3SourceRequest,
+    SourceRequestItem,
     TargetRequest,
 )
 from docling.datamodel.service.targets import (
@@ -24,6 +27,19 @@ from docling_core.types.doc import ImageRefMode
 from docling_serve.settings import DoclingServeSettings
 
 ALL_TARGET_TYPES = frozenset({"inbody", "zip", "s3", "put", "presigned_url"})
+
+
+def _source_kinds(annotated: Any) -> frozenset[str]:
+    """Discriminator ``kind`` literals of an ``Annotated[Union[...], ...]`` alias."""
+    union = typing.get_args(annotated)[0]  # strip Annotated -> Union
+    return frozenset(m.model_fields["kind"].default for m in typing.get_args(union))
+
+
+# Derived from the endpoint source unions so it can never drift past what the
+# request models actually accept; allowed_source_types only ever narrows this.
+ALL_SOURCE_TYPES = _source_kinds(SourceRequestItem) | _source_kinds(
+    BatchSourceRequestItem
+)
 _ConvertRequestT = TypeVar(
     "_ConvertRequestT", ConvertSourcesRequest, BatchConvertSourcesRequest
 )
@@ -35,6 +51,7 @@ class ServicePolicy:
     max_images_scale: float
     allow_external_plugins: bool
     allowed_ocr_presets: frozenset[str]
+    allowed_source_types: frozenset[str]
     allowed_target_types: frozenset[str]
     callbacks_enabled: bool
     custom_vlm_enabled: bool
@@ -52,6 +69,12 @@ def build_service_policy(settings: DoclingServeSettings) -> ServicePolicy:
         allowed_ocr_presets = registered_ocr_presets
     else:
         allowed_ocr_presets = set(settings.allowed_ocr_presets) & registered_ocr_presets
+    if settings.allowed_source_types is None:
+        allowed_source_types = ALL_SOURCE_TYPES
+    else:
+        allowed_source_types = (
+            frozenset(settings.allowed_source_types) & ALL_SOURCE_TYPES
+        )
     if settings.allowed_target_types is None:
         allowed_target_types = ALL_TARGET_TYPES
     else:
@@ -75,6 +98,7 @@ def build_service_policy(settings: DoclingServeSettings) -> ServicePolicy:
         max_images_scale=settings.max_images_scale,
         allow_external_plugins=settings.allow_external_plugins,
         allowed_ocr_presets=frozenset(allowed_ocr_presets),
+        allowed_source_types=allowed_source_types,
         allowed_target_types=allowed_target_types,
         callbacks_enabled=True,
         custom_vlm_enabled=settings.allow_custom_vlm_config,
@@ -203,10 +227,23 @@ def validate_target_kind(target_kind: str, policy: ServicePolicy) -> None:
     )
 
 
+def validate_source_kinds(sources: Any, policy: ServicePolicy) -> None:
+    for source in sources:
+        if source.kind not in policy.allowed_source_types:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=(
+                    f"source kind '{source.kind}' is not allowed. "
+                    f"Allowed values: {sorted(policy.allowed_source_types)}."
+                ),
+            )
+
+
 def validate_convert_request(
     request: ConvertSourcesRequest, policy: ServicePolicy
 ) -> None:
     validate_convert_options(request.options, policy)
+    validate_source_kinds(request.sources, policy)
     validate_target_kind(request.target.kind, policy)
 
     if request.callbacks and not policy.callbacks_enabled:
@@ -257,6 +294,7 @@ def validate_batch_convert_request(
     request: BatchConvertSourcesRequest, policy: ServicePolicy
 ) -> None:
     validate_convert_options(request.options, policy)
+    validate_source_kinds(request.sources, policy)
 
     if request.callbacks and not policy.callbacks_enabled:
         raise HTTPException(
@@ -301,6 +339,7 @@ def validate_chunk_request(
     request: BaseChunkDocumentsRequest, policy: ServicePolicy
 ) -> None:
     validate_convert_options(request.convert_options, policy)
+    validate_source_kinds(request.sources, policy)
     validate_target_kind(request.target.kind, policy)
 
     if request.callbacks and not policy.callbacks_enabled:

--- a/docling_serve/settings.py
+++ b/docling_serve/settings.py
@@ -371,7 +371,8 @@ class DoclingServeSettings(BaseSettings):
     custom_ocr_presets: dict[str, Any] = Field(default_factory=dict)
     allowed_ocr_kinds: Optional[list[str]] = None
 
-    # Target Control
+    # Source / Target Control
+    allowed_source_types: Optional[list[str]] = None
     allowed_target_types: Optional[list[str]] = None
 
     @classmethod
@@ -436,6 +437,7 @@ class DoclingServeSettings(BaseSettings):
         "allowed_layout_presets",
         "allowed_ocr_presets",
         "allowed_ocr_kinds",
+        "allowed_source_types",
         "allowed_target_types",
         "allowed_image_export_modes",
         mode="before",

--- a/tests/test_env_parsing.py
+++ b/tests/test_env_parsing.py
@@ -49,6 +49,14 @@ def test_allowed_target_types_from_csv(monkeypatch):
     assert settings.allowed_target_types == ["zip", "presigned_url", "inbody"]
 
 
+def test_allowed_source_types_from_csv(monkeypatch):
+    monkeypatch.setenv("DOCLING_SERVE_ALLOWED_SOURCE_TYPES", "http, s3")
+
+    settings = DoclingServeSettings()
+
+    assert settings.allowed_source_types == ["http", "s3"]
+
+
 def test_default_values():
     """Test default values for new parameters."""
     settings = DoclingServeSettings()

--- a/tests/test_service_policy.py
+++ b/tests/test_service_policy.py
@@ -6,6 +6,7 @@ from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.datamodel.service.requests import (
     BatchConvertSourcesRequest,
     ConvertSourcesRequest,
+    FileSourceRequest,
     HttpSourceRequest,
     S3SourceRequest,
 )
@@ -13,6 +14,7 @@ from docling.datamodel.service.targets import InBodyTarget, PresignedUrlTarget, 
 
 from docling_serve.datamodel.convert import ConvertDocumentsRequestOptions
 from docling_serve.policy import (
+    ALL_SOURCE_TYPES,
     ALL_TARGET_TYPES,
     build_service_policy,
     normalize_convert_options,
@@ -329,3 +331,53 @@ def test_validate_convert_request_rejects_disallowed_target_type():
 
     with pytest.raises(HTTPException, match="target kind 'inbody' is not allowed"):
         validate_convert_request(request, policy)
+
+
+def test_build_service_policy_allows_all_source_types_by_default():
+    policy = build_service_policy(DoclingServeSettings())
+
+    assert policy.allowed_source_types == ALL_SOURCE_TYPES
+    assert ALL_SOURCE_TYPES == frozenset({"file", "http", "s3"})
+
+
+def test_allowed_source_types_cannot_extend_beyond_union():
+    policy = build_service_policy(
+        DoclingServeSettings(allowed_source_types=["http", "ftp"])
+    )
+
+    assert policy.allowed_source_types == frozenset({"http"})
+
+
+def test_validate_convert_request_rejects_disallowed_source_type():
+    policy = build_service_policy(DoclingServeSettings(allowed_source_types=["http"]))
+    request = ConvertSourcesRequest(
+        options=ConvertDocumentsOptions(),
+        sources=[FileSourceRequest(base64_string="", filename="a.pdf")],
+        target=InBodyTarget(),
+    )
+
+    with pytest.raises(HTTPException, match="source kind 'file' is not allowed"):
+        validate_convert_request(request, policy)
+
+
+def test_validate_batch_convert_request_rejects_disallowed_source_type():
+    policy = build_service_policy(DoclingServeSettings(allowed_source_types=["http"]))
+    request = BatchConvertSourcesRequest(
+        sources=[
+            S3SourceRequest(
+                endpoint="s3.example.com",
+                access_key="key",
+                secret_key="secret",
+                bucket="bucket",
+            )
+        ],
+        target=S3Target(
+            endpoint="s3.example.com",
+            access_key="key",
+            secret_key="secret",
+            bucket="converted",
+        ),
+    )
+
+    with pytest.raises(HTTPException, match="source kind 's3' is not allowed"):
+        validate_batch_convert_request(request, policy)


### PR DESCRIPTION
## Add `allowed_source_types` policy control

Deployments could restrict result destinations with `allowed_target_types`, but nothing constrained source kinds — the endpoints accepted anything in the request union types. This adds a symmetric `allowed_source_types` control.

### What changed

- New `allowed_source_types` setting (`Optional[list[str]]`, defaults to all allowed), parsed from CSV/JSON env like the other allow-lists.
- `ALL_SOURCE_TYPES` is derived at import time from the actual endpoint source unions (`SourceRequestItem`, `BatchSourceRequestItem`) rather than hardcoded, so it tracks the request models and a configured list can only intersect it — never extend beyond `{file, http, s3}`.
- `validate_source_kinds` enforces the allow-list on the convert, batch-convert, and chunk endpoints, returning 422 for a disallowed source kind.

### Notes

- Existing S3 source/target pairing checks are unchanged and still run; disallowing `s3` just rejects earlier with a clearer message.
- Default behavior is unchanged: with no setting configured, all source kinds remain allowed.
