### PR TITLE
fix: support target not just target type in multipart requests

### DIFF
--- a/docling_serve/app.py
+++ b/docling_serve/app.py
@@ -36,7 +36,7 @@ from fastapi.openapi.docs import (
 )
 from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import create_model
+from pydantic import TypeAdapter, ValidationError, create_model
 from scalar_fastapi import get_scalar_api_reference
 
 from docling.datamodel.base_models import DocumentStream
@@ -76,7 +76,6 @@ from docling.datamodel.service.responses import (
 )
 from docling.datamodel.service.targets import (
     InBodyTarget,
-    PresignedUrlTarget,
     ZipTarget,
 )
 from docling.datamodel.service.tasks import TaskType
@@ -158,6 +157,44 @@ _models_ready = asyncio.Event()
 # push delivery while polling still succeeds, which is otherwise very hard to
 # detect.
 _queue_processor_failed = asyncio.Event()
+
+_TARGET_REQUEST_ADAPTER: TypeAdapter[TargetRequest] = TypeAdapter(TargetRequest)
+
+
+def _parse_multipart_target(
+    *,
+    target: str | None,
+    target_type: str | None,
+    default_target: TargetRequest,
+) -> TargetRequest:
+    """Build a typed target from the multipart compatibility fields."""
+    if target is None:
+        target_payload: str | dict[str, str] = {
+            "kind": target_type or default_target.kind
+        }
+    else:
+        target_payload = target
+
+    try:
+        if isinstance(target_payload, str):
+            parsed_target = _TARGET_REQUEST_ADAPTER.validate_json(target_payload)
+        else:
+            parsed_target = _TARGET_REQUEST_ADAPTER.validate_python(target_payload)
+    except ValidationError as exc:
+        # Target payloads can contain credentials. Do not expose Pydantic's input
+        # rendering in the public response.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Invalid multipart target configuration.",
+        ) from exc
+
+    if target_type is not None and target_type != parsed_target.kind:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Multipart target_type must match target.kind.",
+        )
+
+    return parsed_target
 
 
 def _supervise_queue_processor(task: asyncio.Task, failed_event: asyncio.Event) -> None:
@@ -259,7 +296,6 @@ def create_app():  # noqa: C901
     # a concrete value it also flows into the OpenAPI schema automatically. The
     # subclass keeps the public "ConvertSourcesRequest" schema name.
     default_target = resolve_default_target(service_policy)
-    default_target_name = TargetName(default_target.kind)
     ConvertSourcesRequestModel = create_model(
         "ConvertSourcesRequest",
         __base__=ConvertSourcesRequest,
@@ -659,10 +695,13 @@ def create_app():  # noqa: C901
         validate_convert_options(normalized_options, service_policy)
         return normalized_options
 
+    def _validate_multipart_target(target: TargetRequest) -> None:
+        validate_target_kind(target.kind, service_policy)
+
     def _validate_multipart_target_type(target_type: TargetName) -> None:
         validate_target_kind(target_type.value, service_policy)
 
-    def _check_file_upload(files: list[UploadFile], target_type: TargetName) -> None:
+    def _check_file_upload(files: list[UploadFile], target: TargetRequest) -> None:
         if len(files) > service_policy.max_sources_per_request:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -672,7 +711,7 @@ def create_app():  # noqa: C901
                 ),
             )
         if (
-            target_type == TargetName.PRESIGNED_URL
+            target.kind == TargetName.PRESIGNED_URL.value
             and not service_policy.artifact_storage_enabled
         ):
             raise HTTPException(
@@ -682,13 +721,6 @@ def create_app():  # noqa: C901
                     "and enabled on the server."
                 ),
             )
-
-    def _resolve_file_target(target_type: TargetName) -> TargetRequest:
-        if target_type == TargetName.PRESIGNED_URL:
-            return PresignedUrlTarget()
-        if target_type == TargetName.ZIP:
-            return ZipTarget()
-        return InBodyTarget()
 
     ##########################################
     # Downgrade openapi 3.1 to 3.0.x helpers #
@@ -925,17 +957,38 @@ def create_app():  # noqa: C901
         options: Annotated[
             ConvertDocumentsRequestOptions, FormDepends(ConvertDocumentsRequestOptions)
         ],
-        target_type: Annotated[TargetName, Form()] = default_target_name,
+        target: Annotated[
+            str | None,
+            Form(
+                description=(
+                    "Complete output target as JSON. When target_type is also "
+                    "provided, it must match this object's kind."
+                )
+            ),
+        ] = None,
+        target_type: Annotated[
+            str | None,
+            Form(
+                description=(
+                    "Legacy output target discriminator. Structured storage "
+                    "targets also require the target JSON field."
+                )
+            ),
+        ] = None,
         x_tenant_id: Annotated[
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
     ):
-        _check_file_upload(files, target_type)
+        resolved_target = _parse_multipart_target(
+            target=target,
+            target_type=target_type,
+            default_target=default_target,
+        )
+        _check_file_upload(files, resolved_target)
         options = _prepare_convert_options(options)
-        _validate_multipart_target_type(target_type)
+        _validate_multipart_target(resolved_target)
         tenant_id = _get_tenant_id_from_header(x_tenant_id)
         _log.info(f"[TENANT_ID] process_file endpoint received tenant_id='{tenant_id}'")
-        target = _resolve_file_target(target_type)
         task = await _enqueue_file(
             task_type=TaskType.CONVERT,
             orchestrator=orchestrator,
@@ -943,7 +996,7 @@ def create_app():  # noqa: C901
             convert_options=options,
             chunking_options=None,
             chunking_export_options=None,
-            target=target,
+            target=resolved_target,
             callbacks=[],
             tenant_id=tenant_id,
         )
@@ -1057,19 +1110,40 @@ def create_app():  # noqa: C901
         options: Annotated[
             ConvertDocumentsRequestOptions, FormDepends(ConvertDocumentsRequestOptions)
         ],
-        target_type: Annotated[TargetName, Form()] = default_target_name,
+        target: Annotated[
+            str | None,
+            Form(
+                description=(
+                    "Complete output target as JSON. When target_type is also "
+                    "provided, it must match this object's kind."
+                )
+            ),
+        ] = None,
+        target_type: Annotated[
+            str | None,
+            Form(
+                description=(
+                    "Legacy output target discriminator. Structured storage "
+                    "targets also require the target JSON field."
+                )
+            ),
+        ] = None,
         x_tenant_id: Annotated[
             str | None, Header(alias=docling_serve_settings.eng_ray_tenant_id_header)
         ] = None,
     ):
-        _check_file_upload(files, target_type)
+        resolved_target = _parse_multipart_target(
+            target=target,
+            target_type=target_type,
+            default_target=default_target,
+        )
+        _check_file_upload(files, resolved_target)
         options = _prepare_convert_options(options)
-        _validate_multipart_target_type(target_type)
+        _validate_multipart_target(resolved_target)
         tenant_id = _get_tenant_id_from_header(x_tenant_id)
         _log.info(
             f"[TENANT_ID] process_file_async endpoint received tenant_id='{tenant_id}'"
         )
-        target = _resolve_file_target(target_type)
         task = await _enqueue_file(
             task_type=TaskType.CONVERT,
             orchestrator=orchestrator,
@@ -1077,7 +1151,7 @@ def create_app():  # noqa: C901
             convert_options=options,
             chunking_options=None,
             chunking_export_options=None,
-            target=target,
+            target=resolved_target,
             callbacks=[],
             tenant_id=tenant_id,
         )

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -368,6 +368,21 @@ curl -X POST "localhost:5001/v1/convert/source" \
 
 The endpoint is: `/v1/convert/file`, listening for POST requests of Form payloads (necessary as the files are sent as multipart/form data). You can send one or multiple files.
 
+The `target` form field accepts the complete output target as a JSON object.
+This is required for storage targets such as S3 because their coordinates and
+credentials cannot be represented by the legacy `target_type` discriminator
+alone. If both fields are present, `target_type` must match `target.kind`.
+
+```sh
+curl -X POST 'http://127.0.0.1:5001/v1/convert/file/async' \
+  -F 'files=@document.pdf;type=application/pdf' \
+  -F 'target_type=s3' \
+  -F 'target={"kind":"s3","endpoint":"s3.example.com","access_key":"ACCESS_KEY","secret_key":"SECRET_KEY","bucket":"converted","key_prefix":"results/"}'
+```
+
+For compatibility, `target_type` can still be used by itself for the
+coordinate-free `inbody`, `zip`, and `presigned_url` targets.
+
 <details>
 <summary>CURL example:</summary>
 

--- a/tests/test_batch_endpoint.py
+++ b/tests/test_batch_endpoint.py
@@ -1,3 +1,4 @@
+import json
 from typing import Literal
 from unittest.mock import patch
 
@@ -17,7 +18,16 @@ from docling.datamodel.service.responses import (
     DocumentArtifactItem,
     PresignedArtifactResult,
 )
-from docling.datamodel.service.targets import S3Target
+from docling.datamodel.service.targets import (
+    AzureBlobTarget,
+    GoogleCloudStorageTarget,
+    GoogleDriveTarget,
+    InBodyTarget,
+    PresignedUrlTarget,
+    PutTarget,
+    S3Target,
+    ZipTarget,
+)
 from docling.datamodel.service.tasks import TaskType
 from docling_jobkit.connectors.connector_factory import (
     SourceConnectorFactory,
@@ -329,6 +339,183 @@ async def test_batch_endpoint_accepts_s3_source_with_s3_target(app, fake_orchest
     assert response.json()["task_type"] == TaskType.CONVERT
     assert len(fake_orchestrator.enqueued[0]["sources"]) == 1
     assert isinstance(fake_orchestrator.enqueued[0]["target"], S3Target)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("target", "expected_type"),
+    [
+        ({"kind": "inbody"}, InBodyTarget),
+        ({"kind": "zip"}, ZipTarget),
+        ({"kind": "presigned_url"}, PresignedUrlTarget),
+        ({"kind": "put", "url": "https://example.com/result"}, PutTarget),
+        (
+            {
+                "kind": "s3",
+                "endpoint": "s3.example.com",
+                "access_key": "access-key",
+                "secret_key": "secret-key",
+                "bucket": "converted",
+                "key_prefix": "results/",
+            },
+            S3Target,
+        ),
+        (
+            {
+                "kind": "azure_blob",
+                "account_name": "account",
+                "container": "converted",
+                "connection_string": "UseDevelopmentStorage=true",
+                "blob_prefix": "results/",
+            },
+            AzureBlobTarget,
+        ),
+        (
+            {
+                "kind": "google_cloud_storage",
+                "bucket": "converted",
+                "key_prefix": "results/",
+            },
+            GoogleCloudStorageTarget,
+        ),
+        (
+            {
+                "kind": "google_drive",
+                "path_id": "folder-123",
+                "refresh_token": "refresh-token",
+                "credentials_path": "/run/secrets/google-drive.json",
+            },
+            GoogleDriveTarget,
+        ),
+    ],
+)
+async def test_file_async_accepts_complete_multipart_target(
+    app, fake_orchestrator, target, expected_type
+):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://app.io"
+    ) as client:
+        response = await client.post(
+            "/v1/convert/file/async",
+            files={"files": ("input.md", b"# Test", "text/markdown")},
+            data={
+                "target_type": target["kind"],
+                "target": json.dumps(target),
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert isinstance(fake_orchestrator.enqueued[-1]["target"], expected_type)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("target_type", "expected_type"),
+    [
+        ("inbody", InBodyTarget),
+        ("zip", ZipTarget),
+        ("presigned_url", PresignedUrlTarget),
+    ],
+)
+async def test_file_async_preserves_legacy_target_type(
+    app, fake_orchestrator, target_type, expected_type
+):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://app.io"
+    ) as client:
+        response = await client.post(
+            "/v1/convert/file/async",
+            files={"files": ("input.md", b"# Test", "text/markdown")},
+            data={"target_type": target_type},
+        )
+
+    assert response.status_code == 200, response.text
+    assert isinstance(fake_orchestrator.enqueued[-1]["target"], expected_type)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["/v1/convert/file", "/v1/convert/file/async"])
+async def test_file_endpoints_accept_target_without_legacy_target_type(
+    app, fake_orchestrator, endpoint
+):
+    target = {
+        "kind": "s3",
+        "endpoint": "s3.example.com",
+        "access_key": "access-key",
+        "secret_key": "secret-key",
+        "bucket": "converted",
+    }
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://app.io"
+    ) as client:
+        response = await client.post(
+            endpoint,
+            files={"files": ("input.md", b"# Test", "text/markdown")},
+            data={"target": json.dumps(target)},
+        )
+
+    assert response.status_code == 200, response.text
+    assert isinstance(fake_orchestrator.enqueued[-1]["target"], S3Target)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["/v1/convert/file", "/v1/convert/file/async"])
+async def test_file_endpoints_reject_conflicting_multipart_target_fields(app, endpoint):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://app.io"
+    ) as client:
+        response = await client.post(
+            endpoint,
+            files={"files": ("input.md", b"# Test", "text/markdown")},
+            data={
+                "target_type": "zip",
+                "target": json.dumps({"kind": "inbody"}),
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": "Multipart target_type must match target.kind."
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "target",
+    [
+        "not-json",
+        json.dumps({"kind": "unknown", "token": "must-not-leak"}),
+        json.dumps({"kind": "s3", "secret_key": "must-not-leak"}),
+    ],
+)
+async def test_file_async_rejects_invalid_target_without_echoing_payload(app, target):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://app.io"
+    ) as client:
+        response = await client.post(
+            "/v1/convert/file/async",
+            files={"files": ("input.md", b"# Test", "text/markdown")},
+            data={"target": target},
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "Invalid multipart target configuration."}
+    assert "must-not-leak" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_file_async_rejects_storage_target_type_without_coordinates(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://app.io"
+    ) as client:
+        response = await client.post(
+            "/v1/convert/file/async",
+            files={"files": ("input.md", b"# Test", "text/markdown")},
+            data={"target_type": "s3"},
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "Invalid multipart target configuration."}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The multipart file conversion endpoints only take target_type, rather than the full target object. This works fine for some response targets but breaks for storage targets that need to pass metadata: 

```sh
curl -X POST 'http://127.0.0.1:5001/v1/convert/file/async' \
  -F 'files=@document.pdf;type=application/pdf' \
  -F 'target_type=s3' \
  -F 'target={"kind":"s3","endpoint":"s3.example.com","access_key":"ACCESS_KEY","secret_key":"SECRET_KEY","bucket":"converted","key_prefix":"results/"}'
```

For compatibility, `target_type` can still be used by itself for the `inbody`, `zip`, and `presigned_url` targets.


**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.