### PR TITLE
fix: return 422 instead of 500 for invalid options on the multipart endpoints

### DIFF
--- a/docling_serve/helper_functions.py
+++ b/docling_serve/helper_functions.py
@@ -76,9 +76,9 @@ def _jsonable(value: Any) -> Any:
     ``ctx``; either can be a model instance or an exception object, which would
     either blow up or bloat the error response.
     """
-    if isinstance(value, (str, int, float, bool, type(None))):
+    if isinstance(value, str | int | float | bool | type(None)):
         return value
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, list | tuple):
         return [_jsonable(item) for item in value]
     if isinstance(value, dict):
         return {str(k): _jsonable(v) for k, v in value.items()}

--- a/docling_serve/helper_functions.py
+++ b/docling_serve/helper_functions.py
@@ -4,9 +4,12 @@ import json
 import platform
 import re
 import sys
-from typing import Union, get_args, get_origin
+import types
+from collections.abc import Callable
+from typing import Any, Union, get_args, get_origin
 
 from fastapi import Depends, Form
+from fastapi.exceptions import RequestValidationError
 from pydantic import AnyUrl, BaseModel, TypeAdapter, ValidationError
 
 DOCLING_VERSIONS = {
@@ -21,13 +24,21 @@ DOCLING_VERSIONS = {
 }
 
 
+def is_union(type_) -> bool:
+    """Match both spellings of a union: ``Optional[X]``/``Union[X, Y]`` and ``X | Y``.
+
+    They do not share an origin: `get_origin` returns `typing.Union` for the former
+    and `types.UnionType` for the latter.
+    """
+    return get_origin(type_) in (Union, types.UnionType)
+
+
 def is_pydantic_model(type_):
     try:
         if inspect.isclass(type_) and issubclass(type_, BaseModel):
             return True
 
-        origin = get_origin(type_)
-        if origin is Union:
+        if is_union(type_):
             args = get_args(type_)
             return any(
                 inspect.isclass(arg) and issubclass(arg, BaseModel)
@@ -45,10 +56,9 @@ def is_json_field(type_):
     """Return True for dict fields (including Optional[dict]) that
     must be accepted as JSON strings from multipart form data."""
     try:
-        origin = get_origin(type_)
-        if origin is dict:
+        if get_origin(type_) is dict:
             return True
-        if origin is Union:
+        if is_union(type_):
             for arg in get_args(type_):
                 if arg is type(None):
                     continue
@@ -57,6 +67,44 @@ def is_json_field(type_):
     except Exception:
         pass
     return False
+
+
+def _jsonable(value: Any) -> Any:
+    """Reduce a pydantic error payload to something the 422 response can carry.
+
+    Pydantic puts the offending value in ``input`` and validator internals in
+    ``ctx``; either can be a model instance or an exception object, which would
+    either blow up or bloat the error response.
+    """
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    return str(value)
+
+
+def _as_validation_errors(
+    exc: ValidationError, loc_for: Callable[[tuple[Any, ...]], tuple[Any, ...]]
+) -> list[dict[str, Any]]:
+    """Re-anchor pydantic errors onto the multipart form field that carried them."""
+    errors: list[dict[str, Any]] = []
+    for error in exc.errors(include_url=False):
+        loc = ("body", *loc_for(tuple(error.get("loc", ()))))
+        new_error: dict[str, Any] = {
+            "type": error.get("type", "value_error"),
+            "loc": loc,
+            "msg": error.get("msg", str(exc)),
+        }
+        # Model-level errors carry the whole options object as their input, which on
+        # the form path is every field including the defaults the caller never sent.
+        if "input" in error and loc != ("body",):
+            new_error["input"] = _jsonable(error["input"])
+        if error.get("ctx"):
+            new_error["ctx"] = _jsonable(error["ctx"])
+        errors.append(new_error)
+    return errors
 
 
 # Adapted from
@@ -120,10 +168,12 @@ def FormDepends(
 
     async def as_form_func(**data):
         newdata = {}
+        errors: list[dict[str, Any]] = []
         for field_name, model_field in cls.model_fields.items():
             if field_name in excluded_fields:
                 continue
-            value = data.get(f"{prefix}{field_name}")
+            form_field = f"{prefix}{field_name}"
+            value = data.get(form_field)
             newdata[field_name] = value
             annotation = model_field.annotation
 
@@ -132,15 +182,39 @@ def FormDepends(
                 try:
                     validator = TypeAdapter(annotation)
                     newdata[field_name] = validator.validate_json(value)
-                except Exception as e:
-                    raise ValueError(f"Invalid JSON for field '{field_name}': {e}")
+                except ValidationError as e:
+                    errors.extend(
+                        _as_validation_errors(
+                            e, lambda loc, name=form_field: (name, *loc)
+                        )
+                    )
             elif value is not None and is_json_field(annotation):
                 try:
                     newdata[field_name] = json.loads(value)
-                except Exception as e:
-                    raise ValueError(f"Invalid JSON for field '{field_name}': {e}")
+                except ValueError as e:
+                    errors.append(
+                        {
+                            "type": "json_invalid",
+                            "loc": ("body", form_field),
+                            "msg": f"Invalid JSON: {e}",
+                            "input": value,
+                        }
+                    )
 
-        return cls(**newdata)
+        if errors:
+            raise RequestValidationError(errors)
+
+        try:
+            return cls(**newdata)
+        except ValidationError as e:
+            # Field, cross-field and model validators all land here; their locations
+            # are model field names, which must be mapped back to form field names.
+            raise RequestValidationError(
+                _as_validation_errors(
+                    e,
+                    lambda loc: (f"{prefix}{loc[0]}", *loc[1:]) if loc else (),
+                )
+            ) from e
 
     sig = inspect.signature(as_form_func)
     sig = sig.replace(parameters=new_parameters)
@@ -169,7 +243,12 @@ def parse_callback_item(value: str):
         return CallbackSpec.model_validate_json(value)
     except (ValueError, ValidationError):
         # Treat the raw string as the callback URL.
-        return CallbackSpec(url=AnyUrl(value))
+        try:
+            return CallbackSpec(url=AnyUrl(value))
+        except ValidationError as e:
+            raise RequestValidationError(
+                _as_validation_errors(e, lambda loc: ("callbacks", *loc))
+            ) from e
 
 
 def _to_list_of_strings(input_value: Union[str, list[str]]) -> list[str]:

--- a/tests/test_form_options_validation.py
+++ b/tests/test_form_options_validation.py
@@ -1,0 +1,190 @@
+"""Invalid form options must be reported as 422, not crash with a 500.
+
+The `/v1/convert/file` and `/v1/chunk/file` endpoints take their options as
+multipart form fields, so `FormDepends` has to decode nested models and dict
+fields from JSON strings itself. Every validation failure on that path has to
+surface as a `RequestValidationError`, otherwise FastAPI never sees it as a
+validation problem and the request fails with an unhandled-exception 500 —
+unlike the JSON-body endpoints, which reject the same payload with a 422.
+"""
+
+from typing import Annotated, Optional, Union
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self
+
+from docling_serve.helper_functions import (
+    FormDepends,
+    is_json_field,
+    is_pydantic_model,
+    parse_callback_item,
+)
+
+
+class NestedOptions(BaseModel):
+    enabled: bool = False
+    max_level: int = 6
+
+
+class Options(BaseModel):
+    name: str = "default"
+    # Field constraints are dropped when the field is flattened into a form
+    # parameter, so they are only enforced once the model is rebuilt.
+    threads: int = Field(default=1, ge=1, le=8)
+    nested: NestedOptions = NestedOptions()
+    other: NestedOptions | None = None
+    custom_config: dict[str, str] | None = None
+
+    @model_validator(mode="after")
+    def nested_exclusivity(self) -> Self:
+        if self.nested.enabled and self.other is not None:
+            raise ValueError("nested and other are mutually exclusive")
+        return self
+
+
+@pytest.fixture(scope="module")
+def form_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.post("/options")
+    async def read_options(
+        options: Annotated[Options, FormDepends(Options)],
+    ):
+        return options.model_dump()
+
+    @app.post("/prefixed")
+    async def read_prefixed_options(
+        options: Annotated[Options, FormDepends(Options, prefix="convert_")],
+    ):
+        return options.model_dump()
+
+    return app
+
+
+@pytest.fixture(scope="module")
+def client(form_app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=form_app), base_url="http://app.io")
+
+
+async def test_valid_options_still_pass(client: AsyncClient):
+    response = await client.post(
+        "/options",
+        data={
+            "nested": '{"enabled": true, "max_level": 3}',
+            "custom_config": '{"key": "value"}',
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["nested"] == {"enabled": True, "max_level": 3}
+    assert body["custom_config"] == {"key": "value"}
+
+
+async def test_malformed_json_for_nested_model(client: AsyncClient):
+    response = await client.post("/options", data={"nested": "{not json"})
+
+    assert response.status_code == 422
+    (error,) = response.json()["detail"]
+    assert error["loc"] == ["body", "nested"]
+    assert error["type"] == "json_invalid"
+
+
+async def test_invalid_value_inside_nested_model(client: AsyncClient):
+    response = await client.post("/options", data={"nested": '{"max_level": "high"}'})
+
+    assert response.status_code == 422
+    (error,) = response.json()["detail"]
+    assert error["loc"] == ["body", "nested", "max_level"]
+    assert error["input"] == "high"
+
+
+async def test_malformed_json_for_dict_field(client: AsyncClient):
+    response = await client.post("/options", data={"custom_config": "{oops"})
+
+    assert response.status_code == 422
+    (error,) = response.json()["detail"]
+    assert error["loc"] == ["body", "custom_config"]
+    assert error["type"] == "json_invalid"
+
+
+async def test_model_validator_failure(client: AsyncClient):
+    """Cross-field checks run after the form fields are assembled, and fail there."""
+    response = await client.post(
+        "/options",
+        data={"nested": '{"enabled": true}', "other": '{"enabled": false}'},
+    )
+
+    assert response.status_code == 422
+    (error,) = response.json()["detail"]
+    assert error["loc"] == ["body"]
+    assert "mutually exclusive" in error["msg"]
+    # The whole options object, defaults included, is not echoed back.
+    assert "input" not in error
+
+
+async def test_field_constraint_failure_maps_to_its_form_field(client: AsyncClient):
+    response = await client.post("/prefixed", data={"convert_threads": "99"})
+
+    assert response.status_code == 422
+    (error,) = response.json()["detail"]
+    assert error["loc"] == ["body", "convert_threads"]
+    assert error["type"] == "less_than_equal"
+
+
+async def test_all_invalid_fields_are_reported_together(client: AsyncClient):
+    response = await client.post(
+        "/options",
+        data={"nested": "{nope", "custom_config": "{also nope"},
+    )
+
+    assert response.status_code == 422
+    locations = [error["loc"] for error in response.json()["detail"]]
+    assert ["body", "nested"] in locations
+    assert ["body", "custom_config"] in locations
+
+
+async def test_prefixed_form_fields_keep_their_prefix_in_the_error(client: AsyncClient):
+    response = await client.post("/prefixed", data={"convert_nested": "{nope"})
+
+    assert response.status_code == 422
+    (error,) = response.json()["detail"]
+    assert error["loc"] == ["body", "convert_nested"]
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        Optional[NestedOptions],  # noqa: UP045 - the old spelling is what is under test
+        Union[NestedOptions, None],
+        NestedOptions | None,
+    ],
+)
+def test_optional_nested_models_are_detected_in_both_union_spellings(annotation):
+    assert is_pydantic_model(annotation)
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        Optional[dict[str, str]],  # noqa: UP045 - the old spelling is what is under test
+        Union[dict[str, str], None],
+        dict[str, str] | None,
+    ],
+)
+def test_optional_dicts_are_detected_in_both_union_spellings(annotation):
+    assert is_json_field(annotation)
+
+
+def test_unparsable_callback_raises_a_validation_error():
+    """`parse_callback_item` falls back to a bare URL, which can itself be invalid."""
+    from fastapi.exceptions import RequestValidationError
+
+    with pytest.raises(RequestValidationError) as excinfo:
+        parse_callback_item("not a url")
+
+    (error,) = excinfo.value.errors()
+    assert error["loc"] == ("body", "callbacks")

--- a/tests/test_form_options_validation.py
+++ b/tests/test_form_options_validation.py
@@ -158,7 +158,7 @@ async def test_prefixed_form_fields_keep_their_prefix_in_the_error(client: Async
 @pytest.mark.parametrize(
     "annotation",
     [
-        Optional[NestedOptions],  # noqa: UP045 - the old spelling is what is under test
+        Optional[NestedOptions],
         Union[NestedOptions, None],
         NestedOptions | None,
     ],
@@ -170,7 +170,7 @@ def test_optional_nested_models_are_detected_in_both_union_spellings(annotation)
 @pytest.mark.parametrize(
     "annotation",
     [
-        Optional[dict[str, str]],  # noqa: UP045 - the old spelling is what is under test
+        Optional[dict[str, str]],
         Union[dict[str, str], None],
         dict[str, str] | None,
     ],


### PR DESCRIPTION
Hi maintainers, while running test on #662, i saw a bug so i try to fix it here. Thanks a lot!
Invalid convert/chunk options submitted as `multipart/form-data` crash the request with an unhandled-exception **500** instead of being rejected with a **422**. The JSON-body endpoints reject the very same payloads with a 422, so the two request paths disagree on what a client error looks like.

`FormDepends` flattens nested models and dict fields into form parameters that carry JSON strings, and therefore has to validate them itself. It reported every failure as a plain `ValueError`, which FastAPI has no handler for; the model is also rebuilt with a bare `cls(**newdata)`, so field constraints and `model_validator` checks raise a `pydantic.ValidationError` that escapes the same way. Neither is a `RequestValidationError`, so FastAPI never recognises them as validation problems.

Affected on `/v1/convert/file`, `/v1/convert/file/async`, `/v1/chunk/file` and
`/v1/chunk/file/async`:

| Request | Before | After |
| --- | --- | --- |
| Malformed JSON in a nested option (`pdf_heading_hierarchy_options`, `picture_description_local`, `vlm_pipeline_model_*`, …) | 500 | 422 |
| Well-formed JSON with a bad value inside a nested option | 500 | 422 |
| Malformed JSON in a dict option (`ocr_custom_config`, `layout_custom_config`, …) | 500 | 422 |
| Out-of-range value for a constrained field | 500 | 422 |
| Mutually exclusive options set together (`picture_description_local` + `picture_description_api`) | 500 | 422 |
| Unparsable `callbacks` value | 500 | 422 |

Errors are re-anchored onto the form field that carried them, including the `convert_` / `chunking_` prefixes used by the chunk endpoints, so the response points at the field the client actually sent:

```json
{
  "detail": [
    {
      "type": "int_parsing",
      "loc": ["body", "convert_pdf_heading_hierarchy_options", "max_level"],
      "msg": "Input should be a valid integer, unable to parse string as an integer",
      "input": "banana"
    }
  ]
}
```

All invalid fields in one request are reported together rather than only the first. Model-level errors omit `input`, which on the form path would otherwise echo back the entire options object including every default the caller never sent.

### Also fixed: PEP 604 unions were not recognised

`is_pydantic_model()` and `is_json_field()` matched only `typing.Union`, so a field annotated `SomeOptions | None` rather than `Optional[SomeOptions]` was never flattened into a JSON form field. `get_origin()` returns `types.UnionType` for that spelling, not `typing.Union`. No shipped option field uses it today, so this is latent rather than user-visible — but the repo's own lint rules push new code toward `X | None`, and the next option written that way would silently stop accepting nested values over the form path. Both spellings are now matched.

### Testing

`tests/test_form_options_validation.py` covers each row of the table above, that valid options still round-trip unchanged, that the reported location keeps its form-field prefix, and that both union spellings are detected. The tests fail on
`main` and pass with this change.