### PR TITLE
fix(form): keep model_fields_set truthful on the multipart endpoints (#674)

### DIFF
--- a/docling_serve/helper_functions.py
+++ b/docling_serve/helper_functions.py
@@ -4,7 +4,7 @@ import json
 import platform
 import re
 import sys
-from typing import Union, get_args, get_origin
+from typing import Any, Union, get_args, get_origin
 
 from fastapi import Depends, Form
 from pydantic import AnyUrl, BaseModel, TypeAdapter, ValidationError
@@ -65,6 +65,9 @@ def FormDepends(
     cls: type[BaseModel], prefix: str = "", excluded_fields: list[str] = []
 ):
     new_parameters = []
+    # Value FastAPI substitutes for each field when the client omits it. Used
+    # below to tell an omitted field from one the client actually sent.
+    form_defaults: dict[str, Any] = {}
 
     for field_name, model_field in cls.model_fields.items():
         if field_name in excluded_fields:
@@ -82,13 +85,20 @@ def FormDepends(
             )
         )
 
+        if not model_field.is_required():
+            form_defaults[field_name] = model_field.default
+
         # Flatten nested Pydantic models and dict/list fields by accepting them as JSON strings
         if is_pydantic_model(annotation):
             annotation = str
-            default = Form(
+            form_default = (
                 None
                 if model_field.default is None
-                else json.dumps(model_field.default.model_dump(mode="json")),
+                else json.dumps(model_field.default.model_dump(mode="json"))
+            )
+            form_defaults[field_name] = form_default
+            default = Form(
+                form_default,
                 description=description,
                 examples=None
                 if not model_field.examples
@@ -99,10 +109,12 @@ def FormDepends(
             )
         elif is_json_field(annotation):
             annotation = str
+            form_default = (
+                None if model_field.default is None else json.dumps(model_field.default)
+            )
+            form_defaults[field_name] = form_default
             default = Form(
-                None
-                if model_field.default is None
-                else json.dumps(model_field.default),
+                form_default,
                 description=description,
                 examples=None
                 if not model_field.examples
@@ -124,6 +136,12 @@ def FormDepends(
             if field_name in excluded_fields:
                 continue
             value = data.get(f"{prefix}{field_name}")
+            if field_name in form_defaults and value == form_defaults[field_name]:
+                # The client did not send this field: leave it out so the model
+                # applies its own default and model_fields_set stays truthful.
+                # Validators that key on which fields were set (e.g. syncing a
+                # deprecated option onto its replacement) depend on this.
+                continue
             newdata[field_name] = value
             annotation = model_field.annotation
 

--- a/tests/test_form_field_defaults.py
+++ b/tests/test_form_field_defaults.py
@@ -1,0 +1,98 @@
+"""Tests that FormDepends only reports the fields a client actually sent.
+
+Regression coverage for #674: on the multipart endpoints every option used to be
+passed to the model constructor, so `model_fields_set` claimed the client had set
+every field. Validators that key on which fields were set - such as the one that
+forwards the deprecated `ocr_engine` onto `ocr_preset` - therefore never fired,
+and `ocr_engine` was silently ignored (and never validated) on those endpoints.
+"""
+
+from typing import Annotated, Any, Optional
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self
+
+from docling_serve.helper_functions import FormDepends
+
+
+class _NestedOptions(BaseModel):
+    value: int = 1
+
+
+class _Options(BaseModel):
+    """Mirrors the deprecated-option shape of ConvertDocumentsOptions."""
+
+    old_name: Annotated[str, Field(description="DEPRECATED: use new_name")] = "auto"
+    new_name: Annotated[str, Field(description="Replacement option")] = "auto"
+    do_ocr: bool = True
+    ocr_lang: Optional[list[str]] = None
+    nested: Optional[_NestedOptions] = None
+    custom_config: Optional[dict[str, Any]] = None
+
+    @model_validator(mode="after")
+    def sync_deprecated_option(self) -> Self:
+        if (
+            "old_name" in self.model_fields_set
+            and "new_name" not in self.model_fields_set
+        ):
+            object.__setattr__(self, "new_name", self.old_name)
+        return self
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+
+    @app.post("/options")
+    async def read_options(  # type: ignore[no-untyped-def]
+        options: Annotated[_Options, FormDepends(_Options)],
+    ):
+        return {
+            **options.model_dump(),
+            "fields_set": sorted(options.model_fields_set),
+        }
+
+    return TestClient(app)
+
+
+def test_deprecated_option_is_forwarded_to_its_replacement():
+    response = _client().post("/options", data={"old_name": "tesseract"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["fields_set"] == ["old_name"]
+    assert body["new_name"] == "tesseract"
+
+
+def test_explicit_replacement_wins_over_the_deprecated_option():
+    response = _client().post(
+        "/options", data={"old_name": "tesseract", "new_name": "easyocr"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["new_name"] == "easyocr"
+
+
+def test_omitted_fields_keep_their_model_defaults():
+    response = _client().post("/options", data={"do_ocr": "false"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["fields_set"] == ["do_ocr"]
+    assert body["do_ocr"] is False
+    assert body["old_name"] == "auto"
+    assert body["new_name"] == "auto"
+    assert body["ocr_lang"] is None
+    assert body["nested"] is None
+    assert body["custom_config"] is None
+
+
+def test_json_encoded_fields_are_still_parsed():
+    response = _client().post(
+        "/options",
+        data={"nested": '{"value": 7}', "custom_config": '{"key": "value"}'},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["nested"] == {"value": 7}
+    assert body["custom_config"] == {"key": "value"}
+    assert body["fields_set"] == ["custom_config", "nested"]


### PR DESCRIPTION
Fixes #674.

### What is wrong

On the multipart endpoints (`/v1/convert/file`, `/v1/convert/file/async`, the chunk endpoints), `ocr_engine` is accepted with any value, returns 200, and is then ignored — output is byte-identical to sending nothing. `ocr_preset` on the same request rejects an unknown value with 422 and is honoured.

The two options are supposed to agree: `ConvertDocumentsOptions.validate_ocr_options` forwards the deprecated `ocr_engine` onto `ocr_preset` when the caller set `ocr_engine` and left `ocr_preset` alone, and `validate_convert_options` then rejects a preset that is not registered (`ocr_preset '...' is not allowed`).

That forwarding never happens on the form endpoints. `FormDepends.as_form_func` puts **every** field into `newdata`, including the ones FastAPI filled in from the field default, and passes them all to the constructor. `model_fields_set` therefore always contains `ocr_preset`, the `"ocr_preset" not in fields_set` guard is never true, and the deprecated value is dropped on the floor — accepted, unvalidated, and silently inert. The JSON body endpoints are unaffected because pydantic sees only the keys the client sent.

### The fix

Record the value FastAPI substitutes for each optional field, and skip that field in the constructor call when the submitted value is exactly that default. The model then applies its own default (same resulting value) and `model_fields_set` reflects only what the client actually sent.

After the change, on a form request:

| sent | before | after |
|---|---|---|
| `ocr_engine=tesseract` | `ocr_preset` stays `auto`, engine ignored | `ocr_preset=tesseract`, engine honoured |
| `ocr_engine=nonsense_engine` | 200, ignored | 422 `ocr_preset 'nonsense_engine' is not allowed` |
| `ocr_engine=tesseract&ocr_preset=easyocr` | `easyocr` | `easyocr` (unchanged, explicit preset still wins) |
| nothing | defaults | defaults (unchanged) |

A client that explicitly sends a value equal to the default is treated as not having sent it. That is unavoidable over multipart — the two are indistinguishable on the wire — and it is what the JSON path already does for an omitted key, so the resolved options are identical either way.

### Verification

`tests/test_form_field_defaults.py` builds a small options model with the same deprecated-field shape and drives it through `FormDepends` with `TestClient`. Against `main` 3 of the 4 tests fail (the deprecated value is not forwarded, and `fields_set` lists every field); with this change all 4 pass. The JSON-string paths for nested models and dict fields are covered too and are unchanged.

Ruff 0.9.6 (the pinned pre-commit rev) formatter and linter are clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
