### PR TITLE
fix(cli): let --artifacts-path/--enable-ui reach the uvicorn subprocess

### DIFF
--- a/docling_serve/__main__.py
+++ b/docling_serve/__main__.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import logging
+import os
 import platform
 import sys
 import warnings
@@ -106,19 +107,15 @@ def _run(
         and uvicorn_settings.ssl_keyfile is not None
     )
 
-    if run_subprocess and docling_serve_settings.artifacts_path != artifacts_path:
-        err_console.print(
-            "\n[yellow]:warning: The server will run with reload or multiple workers. \n"
-            "The argument [bold]--artifacts-path[/bold] will be ignored, please set the value \n"
-            "using the environment variable [bold]DOCLING_SERVE_ARTIFACTS_PATH[/bold].[/yellow]"
-        )
-
-    if run_subprocess and docling_serve_settings.enable_ui != enable_ui:
-        err_console.print(
-            "\n[yellow]:warning: The server will run with reload or multiple workers. \n"
-            "The argument [bold]--enable-ui[/bold] will be ignored, please set the value \n"
-            "using the environment variable [bold]DOCLING_SERVE_ENABLE_UI[/bold].[/yellow]"
-        )
+    if run_subprocess:
+        # With reload or multiple workers, uvicorn starts the server through
+        # multiprocessing "spawn". The child re-imports docling_serve.settings
+        # and rebuilds the settings from the environment, so the assignments
+        # below never reach it. Hand the CLI values over through the very
+        # environment variables the settings model reads.
+        if artifacts_path is not None:
+            os.environ["DOCLING_SERVE_ARTIFACTS_PATH"] = str(artifacts_path)
+        os.environ["DOCLING_SERVE_ENABLE_UI"] = str(enable_ui).lower()
 
     # Propagate the settings to the app settings
     docling_serve_settings.artifacts_path = artifacts_path

--- a/tests/test_cli_subprocess_settings.py
+++ b/tests/test_cli_subprocess_settings.py
@@ -1,0 +1,76 @@
+"""The CLI's docling options must survive uvicorn's reload/worker subprocess.
+
+`uvicorn.run(reload=True)` (and `workers > 1`) starts the server through
+multiprocessing "spawn", so the child re-imports `docling_serve.settings` and
+rebuilds `DoclingServeSettings` from the environment. Assigning to the settings
+singleton in the parent therefore never reaches the server. These tests assert
+on that hand-over channel: the environment `_run` leaves behind, read back
+through a fresh `DoclingServeSettings()` exactly as the child builds it.
+"""
+
+import pytest
+import uvicorn
+from typer.testing import CliRunner
+
+import docling_serve.__main__ as cli
+from docling_serve.settings import DoclingServeSettings, docling_serve_settings
+
+DOCLING_ENV = ("DOCLING_SERVE_ENABLE_UI", "DOCLING_SERVE_ARTIFACTS_PATH")
+
+
+@pytest.fixture
+def run_cli(monkeypatch):
+    """Invoke the real CLI with the server stubbed out, and isolate globals."""
+    for name in DOCLING_ENV:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(
+        docling_serve_settings, "enable_ui", DoclingServeSettings().enable_ui
+    )
+    monkeypatch.setattr(
+        docling_serve_settings, "artifacts_path", DoclingServeSettings().artifacts_path
+    )
+
+    captured: dict = {}
+    monkeypatch.setattr(uvicorn, "run", lambda *a, **kw: captured.update(kw))
+
+    def _invoke(*args: str):
+        result = CliRunner().invoke(cli.app, list(args))
+        if result.exception is not None and not isinstance(
+            result.exception, SystemExit
+        ):
+            raise result.exception
+        assert result.exit_code == 0, result.output
+        return captured
+
+    return _invoke
+
+
+def test_dev_enables_the_ui_in_the_reload_subprocess(run_cli):
+    """`docling-serve dev` reloads by default; its --enable-ui default is True."""
+    captured = run_cli("dev")
+
+    assert captured["reload"] is True, "dev is expected to run under the reloader"
+    # What the spawned child rebuilds from the environment:
+    assert DoclingServeSettings().enable_ui is True
+
+
+def test_dev_no_enable_ui_is_propagated_too(run_cli):
+    run_cli("dev", "--no-enable-ui")
+
+    assert DoclingServeSettings().enable_ui is False
+
+
+def test_workers_propagate_artifacts_path(run_cli, tmp_path):
+    run_cli("run", "--workers", "2", "--artifacts-path", str(tmp_path))
+
+    assert DoclingServeSettings().artifacts_path == tmp_path
+
+
+def test_single_process_run_leaves_the_environment_alone(run_cli, monkeypatch):
+    """Without reload/workers the app runs in-process, so the settings object
+    is the channel and the environment must not be rewritten."""
+    captured = run_cli("run", "--no-reload", "--enable-ui")
+
+    assert captured["reload"] is False and captured["workers"] is None
+    assert docling_serve_settings.enable_ui is True
+    assert DoclingServeSettings().enable_ui is False


### PR DESCRIPTION
### The bug

`docling-serve dev` defaults to `--reload`, and `--enable-ui` defaults to `True` there. Running it with no flags today prints these two lines in the same output:

```
:warning: The server will run with reload or multiple workers.
The argument --enable-ui will be ignored, please set the value
using the environment variable DOCLING_SERVE_ENABLE_UI.
...
UI at http://127.0.0.1:5001/ui
```

and then serves nothing at `/ui`. The command whose purpose is the development UI does not start the development UI.

### Why

`uvicorn` starts the reloader **and** every extra worker through `multiprocessing.get_context("spawn")` (`uvicorn/_subprocess.py:18`). The child is a fresh interpreter: it re-imports `docling_serve.settings` and rebuilds `DoclingServeSettings` from the environment, so `_run`'s

```python
docling_serve_settings.enable_ui = enable_ui
```

only ever mutates the parent. `DoclingServeSettings.enable_ui` defaults to `False`, and `app.py:382` gates the UI mount on it — so the child mounts nothing, while the parent (where the value *did* stick) prints the URL.

Reproduced against this branch's parent (`8b9d0a5`), with `uvicorn.run` stubbed and the real CLI invoked:

```
settings default enable_ui  : False
dev() --enable-ui default   : True (literal in the signature)

--- what `docling-serve dev` prints ---
    The argument --enable-ui will be ignored, please set the value
    Server started at http://127.0.0.1:5001
    UI at http://127.0.0.1:5001/ui

uvicorn.run(reload=)        : True
parent settings after _run  : True

--- what the reloader's child process sees ---
    CHILD enable_ui = False   <- no env set (today)
    CHILD enable_ui = True    <- env set (this PR)
```

`--artifacts-path` has the same gap and the same warning.

### The change

Hand the two CLI values over through the environment variables the settings model already reads — precisely what the warnings were asking the user to do by hand — and drop the warnings, which are no longer true:

```python
if run_subprocess:
    if artifacts_path is not None:
        os.environ["DOCLING_SERVE_ARTIFACTS_PATH"] = str(artifacts_path)
    os.environ["DOCLING_SERVE_ENABLE_UI"] = str(enable_ui).lower()
```

**The single-process path is untouched.** The environment is only written when the server actually runs in a subprocess; otherwise the settings object remains the channel, exactly as before. `artifacts_path` is skipped when `None` so an existing `DOCLING_SERVE_ARTIFACTS_PATH` is never clobbered by the flag's own default.

This makes the CLI win over the environment when both are given, which is the normal precedence and what `dev`'s docstring already promises ("Options can be set also with the corresponding ENV variable, **with the exception of --enable-ui**, --host and --reload"). Anyone who wants the UI off in dev uses `--no-enable-ui`.

### Tests

`tests/test_cli_subprocess_settings.py` invokes the real CLI with `uvicorn.run` stubbed and asserts on the hand-over channel itself — a fresh `DoclingServeSettings()`, built the same way the spawned child builds it.

On `8b9d0a5` without the fix: **2 failed, 2 passed**

```
FAILED test_dev_enables_the_ui_in_the_reload_subprocess - AssertionError: assert False is True
FAILED test_workers_propagate_artifacts_path - AssertionError: assert None == WindowsPath('...')
```

With the fix: **4 passed**. The two that already pass on `main` are the guards — `--no-enable-ui` must propagate too, and the single-process path must leave the environment alone.

(`tests/test_config_file_loading.py` has 2 failures on this machine both before and after this change; they are Windows path-separator artifacts unrelated to this PR.)

`ruff check` and `ruff format --diff` clean at the pinned `v0.9.6`.

### Not in scope

Only the two options `_run` already warned about are propagated. Other `DOCLING_SERVE_*` settings are not exposed as CLI flags on `dev`/`run`, so they have no such gap.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
