### PR TITLE
docs: add Nebius Serverless Endpoint deployment example

### DIFF
--- a/docs/deploy-examples/nebius-serverless/README.md
+++ b/docs/deploy-examples/nebius-serverless/README.md
@@ -1,0 +1,182 @@
+# Nebius Serverless Endpoint
+
+Run one Docling Serve GPU container on a [Nebius Serverless Endpoint](https://docs.nebius.com/serverless/overview), submit a document asynchronously, and export Markdown and Docling JSON to a private Object Storage bucket. Nebius manages the container's compute lifecycle; the application uses the existing Docling API.
+
+This example is for a trusted client with one conversion in flight. Its local engine keeps task status in memory. Exported objects can outlive the Endpoint, but accepted tasks cannot resume after the server process is replaced. There is no automatic scale-to-zero or durable queue in this example.
+
+> [!NOTE]
+> Validated on September 11, 2026 with the pinned image, Nebius CLI 0.12.265 and one L40S (`gpu-l40s-a`, `1gpu-16vcpu-64gb`) in `eu-north1`: managed ingress, native SecretStash/S3, text/table and scanned PDFs, independent artifact readback, authentication, input limits, export failure, client resume, stop/start and resource cleanup. These are small fixture checks, not a throughput or production SLA guarantee.
+
+## Prerequisites
+
+- A Nebius project with Serverless permissions, available GPU quota and a subnet in the selected region. Use a regular, single-GPU platform/preset pair available in that project.
+- [Nebius CLI](https://docs.nebius.com/cli/install) with a separately configured operator identity. Command syntax below was inspected with CLI `0.12.265`.
+- A private result bucket in the selected region. Configure retention for `docling-example/`, old object versions where enabled, and incomplete multipart uploads. Bucket storage remains separately billed after the Endpoint stops.
+- [SecretStash](https://docs.nebius.com/mysterybox/overview) secret versions for the keys below. Grant the runtime only access needed to read its secrets and write/read its result objects; do not give the container Endpoint lifecycle credentials.
+- Python 3.10+ on Linux/macOS, with `httpx==0.28.1` for the example client. Store its output directory on durable local storage. The client uses POSIX file locks to prevent two writers using the same receipt.
+
+| Secret selector variable | Payload keys |
+| --- | --- |
+| `INGRESS_SECRET_SELECTOR` | `AUTH_TOKEN` |
+| `APP_SECRET_SELECTOR` | `DOCLING_SERVE_API_KEY` |
+| `STORAGE_SECRET_SELECTOR` | `DOCLING_SERVE_ARTIFACT_STORAGE_ACCESS_KEY`, `DOCLING_SERVE_ARTIFACT_STORAGE_SECRET_KEY` |
+
+Use secret IDs/version selectors from your project, not literal credentials in the configuration file. The storage secret contains S3 credentials, not a Nebius IAM bearer token. The ingress and application authentication tokens should be different. Do not put any of these values in Git or an image, and avoid verbose HTTP tracing that records request headers or signed URLs.
+
+## Image and configuration
+
+This example uses Docling Serve `v1.32.0`, its locked Docling `2.124.0` and Jobkit `3.5.0`, and the published CUDA 12.8 image. The Linux amd64 manifest was inspected on September 11, 2026:
+
+```bash
+export PINNED_IMAGE='ghcr.io/docling-project/docling-serve-cu128@sha256:c57b384ba305ab70f4f8cd02582a0aa9effbc529b7838ddc324a5d299449e8d2'
+```
+
+Keep this value aligned with `IMAGE` in [client.py](client.py), where it is recorded as operator-supplied deployment provenance; the client cannot attest the remotely running image. Revalidate the image after an upgrade. Use an amd64 GPU preset and check driver compatibility, actual Torch CUDA availability and selected OCR engine before claiming GPU acceleration.
+
+The image already contains the default model artifacts. Keep its model directory intact; do not mount an empty directory over it or download models on every request. Extra VLM/code/formula models require separate preparation as described in [model handling](../../models.md). Default startup warm-up uses auto OCR; the first explicit EasyOCR request initializes another pipeline. GPU allocation does not guarantee every OCR stage uses the GPU; the client explicitly requests EasyOCR with `ocr_preset=easyocr`. The deprecated multipart `ocr_engine` field did not override the default `auto` preset in the tested version. Validate its GPU execution separately from layout/table inference.
+
+[docling-config.yaml](docling-config.yaml) selects one Uvicorn process (set below), one local converter worker, shared models and model warm-up. The example policy allows one source, 20 pages and 10 MiB per document, with a 300-second document timeout. It restricts outputs to the server-managed `presigned_url` target. These are starting limits, not measured capacity.
+
+Scratch stays ephemeral. **Do not mount result storage at `DOCLING_SERVE_SCRATCH_PATH`:** the current server shutdown path deletes an explicitly configured scratch directory. Result objects are uploaded through the S3 connector instead. No bucket filesystem mount is required.
+
+## Create the Endpoint
+
+Work from this directory so the injected config path resolves. Set the following non-secret values for your project:
+
+```bash
+export PROJECT_ID='<project-id>'
+export SUBNET_ID='<subnet-id>'
+export ENDPOINT_NAME='docling-example'
+export GPU_PLATFORM='<available-single-gpu-platform>'
+export GPU_PRESET='<matching-single-gpu-preset>'
+export REGION='<bucket-and-endpoint-region>'
+export S3_HOST="storage.${REGION}.nebius.cloud"
+export RESULT_BUCKET='<private-result-bucket>'
+export INGRESS_SECRET_SELECTOR='<ingress-secret-id@version-id>'
+export APP_SECRET_SELECTOR='<app-secret-id@version-id>'
+export STORAGE_SECRET_SELECTOR='<storage-secret-id@version-id>'
+```
+
+`S3_HOST` has **no protocol prefix**; the Docling S3 connector adds HTTPS. Verify the signing region and bucket addressing against the selected Nebius region. The explicit 250 GiB disk and 16 GiB shared memory below are initial allocations, not minimum requirements. Set a test budget and an independent operator stop deadline before launching; an idle Endpoint continues consuming allocated compute.
+
+```bash
+umask 077
+nebius ai endpoint create \
+  --parent-id "$PROJECT_ID" --subnet-id "$SUBNET_ID" \
+  --name "$ENDPOINT_NAME" --image "$PINNED_IMAGE" \
+  --platform "$GPU_PLATFORM" --preset "$GPU_PRESET" \
+  --disk-size 250Gi --shm-size 16Gi \
+  --container-port 5001 \
+  --auth token --token-secret "$INGRESS_SECRET_SELECTOR" \
+  --inject-file 'docling-config.yaml:/etc/docling/config.yaml' \
+  --env DOCLING_SERVE_CONFIG_FILE=/etc/docling/config.yaml \
+  --env UVICORN_HOST=0.0.0.0 --env UVICORN_PORT=5001 --env UVICORN_WORKERS=1 \
+  --env DOCLING_DEVICE=cuda:0 \
+  --env "DOCLING_SERVE_ARTIFACT_STORAGE_ENDPOINT=$S3_HOST" \
+  --env "DOCLING_SERVE_ARTIFACT_STORAGE_BUCKET=$RESULT_BUCKET" \
+  --env "AWS_DEFAULT_REGION=$REGION" \
+  --env-secret "DOCLING_SERVE_API_KEY=$APP_SECRET_SELECTOR" \
+  --env-secret "DOCLING_SERVE_ARTIFACT_STORAGE_ACCESS_KEY=$STORAGE_SECRET_SELECTOR" \
+  --env-secret "DOCLING_SERVE_ARTIFACT_STORAGE_SECRET_KEY=$STORAGE_SECRET_SELECTOR" \
+  --async --format json > create-receipt.txt
+```
+
+The image's default `docling-serve run` command listens on port 5001. A managed HTTPS URL needs neither `--public` nor an SSH key. Injected files are read-only and limited to 64 KiB. See [Endpoint management](https://docs.nebius.com/serverless/endpoints/manage) for current flags and IAM prerequisites.
+
+CLI `0.12.265` prints `Endpoint ID: <id>` for this create command, even with `--format json`; it does not return a JSON operation receipt. Save the text response and use that Endpoint ID to observe provisioning. If create times out or its response is lost, reconcile the resource in the console or with `get-by-name` before retrying. A name alone does not prove resource identity. Do not run create repeatedly while waiting for models or capacity.
+
+```bash
+export ENDPOINT_ID='<id-from-create-receipt>'
+nebius ai endpoint get --id "$ENDPOINT_ID" --format json
+```
+
+Observe the Endpoint state until startup succeeds or fails. From the Endpoint's `status.public_endpoints`, copy the HTTPS origin for port 5001 into `ENDPOINT_URL`. Do not construct a hostname or append `/v1`. Provider `RUNNING` alone does not mean the models are loaded: check `/ready` before submission. The client checks it too. A client timeout ends observation, not remote provisioning; continue inspecting the same Endpoint ID. The [lifecycle documentation](https://docs.nebius.com/serverless/lifecycle) describes capacity and failure states.
+
+## Convert and collect results
+
+Load `NEBIUS_ENDPOINT_TOKEN` and `DOCLING_API_KEY` securely into the client's environment from the matching ingress and application secrets. These are runtime request tokens, not the operator's IAM credential. The client sends both `Authorization: Bearer ...` and `X-Api-Key` to Docling, and sends neither to storage.
+
+```bash
+python -m venv .client-venv
+.client-venv/bin/python -m pip install 'httpx==0.28.1'
+export ENDPOINT_URL='<managed-https-origin>'
+.client-venv/bin/python client.py \
+  --endpoint "$ENDPOINT_URL" --endpoint-id "$ENDPOINT_ID" \
+  --storage-host "$S3_HOST" --bucket "$RESULT_BUCKET" \
+  --file ./document.pdf --output ./conversion-001 --timeout 900
+```
+
+Submit one small PDF first. The client also accepts local formats supported by Docling. It snapshots at most 10 MiB of input, sends one multipart async request, polls status, and retrieves the result. The requested output formats are Markdown and JSON with placeholder images. It requires one fully successful document and both artifacts; a partial conversion fails the example.
+
+The output directory must not already exist for a new submission. The client writes:
+
+- `receipt.json` before submitting, initially with `submission_unknown`; after acknowledgment, it records `task_id` and `submitted`. It contains input/options hashes, Endpoint identity, image provenance and unsigned bucket/key references when available.
+- `document.md` and `document.json`, each bounded to 20 MiB. Remote filenames never control local paths. Downloads require HTTPS and the configured storage host/bucket/task prefix; redirects are rejected.
+- `manifest.json` only after both downloads pass structure checks and local checksum readback. It contains stable bucket/key references, sizes and SHA-256 values, with no signed URLs or tokens. Preserve it in application-owned durable storage.
+
+These checks establish the downloaded bytes and basic output shape. They do not prove OCR quality or compare against an independently supplied remote checksum. For production acceptance, independently read the objects using a separate storage identity and compare content/expected fixture text.
+
+### Recover client observation
+
+If the client stops after recording a task ID, observe that task again with the same configuration and output directory:
+
+```bash
+.client-venv/bin/python client.py \
+  --endpoint "$ENDPOINT_URL" --endpoint-id "$ENDPOINT_ID" \
+  --storage-host "$S3_HOST" --bucket "$RESULT_BUCKET" \
+  --output ./conversion-001 --resume --timeout 900
+```
+
+Resume never sends a new conversion POST. If a completion manifest already exists, it verifies the saved files locally. If the receipt says `submission_unknown`, stop and reconcile manually: Docling offers no demonstrated idempotent submission contract here. A crash before dispatch is also conservatively unknown. A failure before a receipt exists means this client did not dispatch the conversion.
+
+GET observations have at most three attempts for transient transport errors or HTTP 429/502/503/504. The overall deadline bounds client work; it does not cancel conversion or stop the Endpoint. Downloads are not automatically retried midstream. An interrupted download can be attempted again with resume while the task and signed URLs remain available.
+
+The example retains fetched task results for one hour and issues one-hour artifact URLs. Fetching again does not promise URL renewal. A 404 may indicate process replacement or result cleanup; it does not authorize resubmission. Preserve receipts and inspect the result prefix. Expired URLs do not delete objects: use stable bucket/key references with an authorized storage client. Avoid logging returned result bodies because they contain signed URLs.
+
+## Operating limits
+
+- Authentication is for a shared trusted client, not individual users or tenant isolation. A task UUID is not an authorization boundary. HTTP sources and callbacks can cause outbound requests; disabling remote model services does not disable all egress.
+- One worker does not limit pending submissions: the local queue is unbounded. Use one in-flight request and add admission controls before opening the service to more clients. File/page limits apply to document processing; multipart input can enter memory before those checks.
+- The 300-second document timeout is not a queue-wait or hard GPU termination guarantee. Synchronous HTTP wait and Uvicorn keep-alive settings are different limits.
+- Output size limits in the client do not cap server generation/upload. Keep enrichment and embedded image exports out of this example. Managed ingress request/response limits and drain/restart behavior need separate validation.
+- Container/process replacement loses local task status. The `presigned_url` target persists files, not the queue. Use an independently validated RQ deployment for a recoverable service, or finite Serverless Jobs for batch workloads.
+- Partial uploads can remain after a failed task. A completed object is not evidence the whole conversion succeeded. Treat the completion manifest as the application publication marker, and configure cleanup of abandoned prefixes/multipart uploads.
+
+## Stop, restart and cleanup
+
+Stop admitting work, drain known tasks and save their verified artifacts before maintenance. The client never starts, stops or deletes the Endpoint.
+
+```bash
+nebius ai endpoint stop --id "$ENDPOINT_ID" --async --format json
+# CLI 0.12.265 prints a bare operation ID, even with --format json.
+# Save that ID, then wait for and inspect the operation.
+nebius ai endpoint operation wait --id '<stop-operation-id>' --timeout 35m
+nebius ai endpoint get --id "$ENDPOINT_ID" --format json
+
+nebius ai endpoint start --id "$ENDPOINT_ID" --async --format json
+# Save the bare start operation ID, wait for it, then recheck /ready.
+```
+
+Completed deletion can also remove the operation record; operation `NotFound` alone is not cleanup proof. Confirm the Endpoint and recorded VM/disk IDs are gone. Do not equate a status transition with completed cleanup. Expect old task IDs to disappear when the process is replaced, while bucket objects remain. When the Endpoint is no longer needed:
+
+```bash
+nebius ai endpoint delete --id "$ENDPOINT_ID" --async --format json
+nebius ai endpoint operation wait --id '<delete-operation-id>' --timeout 35m
+nebius ai endpoint get --id "$ENDPOINT_ID" --format json
+# Confirm NotFound; if the operation failed or resources linger, investigate it.
+```
+
+Nebius documents deletion of the managed VM and boot disk with the Endpoint. Before deletion, record each `status.instances[].compute_instance_id` and read its `spec.boot_disk.existing_disk.id`. Managed resources can belong to an `appbox` container and be absent from project-level Compute lists. After deletion, query the recorded IDs directly; record/support-investigate anything still present. Delete only test-owned objects, versions, incomplete uploads and secret versions when they are no longer needed. Endpoint deletion does not delete the result bucket or revoke its credentials. Never recursively delete a shared bucket as part of this example.
+
+To clear old *finished* tasks while keeping the server alive, the existing authenticated API is `GET /v1/clear/results?older_then=3600` (the parameter spelling is intentional). It clears task results, not Object Storage objects. Abandoned tasks/results and bucket retention need operator management even when single-use results are enabled.
+
+## Validate an installation
+
+Before describing a configuration as supported, record the image/model versions and GPU/OCR provider, verify missing/wrong-token rejection, convert a text/table and scanned PDF, exercise input/output limits, and independently read back artifacts. Test client disconnect/resume, upload failure, stop/start, URL expiry and cleanup. Confirm that process loss is reported as task loss rather than successful recovery. Repeat these GPU/provider checks within a separately bounded budget when changing the image, region or hardware. The validation above confirmed application URLs declare a one-hour TTL and separately checked native S3 expiry with a two-second URL; it did not await the application URL’s full hour or measure all ingress/output limits.
+
+The client regression tests run without cloud credentials:
+
+```bash
+# From the repository root, using the project's development environment:
+uv run --no-sync pytest tests/test_nebius_serverless_client.py
+```

--- a/docs/deploy-examples/nebius-serverless/client.py
+++ b/docs/deploy-examples/nebius-serverless/client.py
@@ -1,0 +1,447 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+"""Bounded single-document client. Requires Python 3.10+, httpx and POSIX locks.
+
+No cloud lifecycle calls. A submission with an unknown outcome is never replayed.
+"""
+
+import argparse
+import asyncio
+import fcntl
+import hashlib
+import json
+import math
+import os
+import re
+import sys
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+from uuid import UUID
+
+import httpx
+
+IMAGE = "ghcr.io/docling-project/docling-serve-cu128@sha256:c57b384ba305ab70f4f8cd02582a0aa9effbc529b7838ddc324a5d299449e8d2"
+MAX_INPUT = 10 * 1024 * 1024
+MAX_JSON = 1024 * 1024
+MAX_ARTIFACT = 20 * 1024 * 1024
+OPTIONS = {
+    "to_formats": ["md", "json"],
+    "image_export_mode": "placeholder",
+    "do_ocr": "true",
+    "ocr_preset": "easyocr",
+    "target_type": "presigned_url",
+}
+
+
+class ExampleError(Exception):
+    """Messages must never contain response bodies, credentials or signed URLs."""
+
+
+def require(condition, message):
+    if not condition:
+        raise ExampleError(message)
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def save_json(path, data):
+    """Replace a local receipt/manifest only after its bytes reach the filesystem."""
+    temporary = path.with_suffix(".tmp")
+    with temporary.open("w", encoding="utf-8") as stream:
+        json.dump(data, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, path)
+    directory_fd = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+@contextmanager
+def locked_output(output, resume):
+    if not resume:
+        output.mkdir(mode=0o700, parents=False, exist_ok=False)
+    require(output.is_dir() and not output.is_symlink(), "Invalid output directory.")
+    with (output / ".lock").open("a") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            raise ExampleError(
+                "Another client is using this output directory."
+            ) from None
+        yield
+
+
+def validate_endpoint(endpoint):
+    url = urlsplit(endpoint)
+    require(
+        url.scheme == "https"
+        and bool(url.hostname)
+        and url.port in (None, 443)
+        and not url.username
+        and not url.password
+        and url.path in ("", "/")
+        and not url.query
+        and not url.fragment,
+        "Endpoint must be a managed HTTPS origin without a path or query.",
+    )
+    return endpoint.rstrip("/")
+
+
+def artifact_identity(uri, storage_host, bucket, task_id):
+    url = urlsplit(uri)
+    require(
+        url.scheme == "https"
+        and url.port in (None, 443)
+        and not url.username
+        and not url.password
+        and not url.fragment,
+        "Artifact URL must use HTTPS without user information or a fragment.",
+    )
+    path = unquote(url.path).lstrip("/")
+    if url.hostname == storage_host:
+        require(path.startswith(bucket + "/"), "Artifact bucket mismatch.")
+        key = path[len(bucket) + 1 :]
+    elif url.hostname == f"{bucket}.{storage_host}":
+        key = path
+    else:
+        raise ExampleError("Artifact storage host mismatch.")
+    parts = key.split("/")
+    require(
+        len(parts) == 6
+        and parts[0:2] == ["docling-example", "default"]
+        and re.fullmatch(r"\d{8}", parts[2]) is not None
+        and parts[3] == task_id
+        and all(p not in ("", ".", "..") and "\\" not in p for p in parts),
+        "Artifact key is outside this example's task prefix.",
+    )
+    return {"bucket": bucket, "key": key}
+
+
+async def read_bounded(response, maximum):
+    body = bytearray()
+    async for block in response.aiter_bytes():
+        body.extend(block)
+        require(len(body) <= maximum, "Response exceeds the configured byte limit.")
+    return bytes(body)
+
+
+class ConversionClient:
+    def __init__(self, api, storage, endpoint, output, storage_host, bucket):
+        self.api = api
+        self.storage = storage
+        self.endpoint = endpoint
+        self.output = output
+        self.storage_host = storage_host
+        self.bucket = bucket
+
+    async def request_json(self, method, path, **kwargs):
+        # Only observations are retried, never a POST or a partial download.
+        for attempt in range(3):
+            try:
+                async with self.api.stream(
+                    method, self.endpoint + path, **kwargs
+                ) as res:
+                    if method == "GET" and res.status_code in (429, 502, 503, 504):
+                        if attempt < 2:
+                            await asyncio.sleep(2**attempt)
+                            continue
+                    require(
+                        res.status_code == 200, f"API returned HTTP {res.status_code}."
+                    )
+                    value = json.loads(await read_bounded(res, MAX_JSON))
+                    require(isinstance(value, dict), "Malformed API response.")
+                    return value
+            except httpx.TransportError:
+                if method != "GET" or attempt == 2:
+                    raise ExampleError(
+                        "API transport failed; submission was not replayed."
+                    ) from None
+                await asyncio.sleep(2**attempt)
+        raise ExampleError("API observations exhausted their retry limit.")
+
+    async def submit(self, input_path, endpoint_id):
+        with input_path.open("rb") as source:
+            data = source.read(MAX_INPUT + 1)
+        require(0 < len(data) <= MAX_INPUT, "Input must contain at most 10 MiB.")
+        receipt = {
+            "version": 1,
+            "endpoint": self.endpoint,
+            "endpoint_id": endpoint_id,
+            "image": IMAGE,
+            "storage_host": self.storage_host,
+            "bucket": self.bucket,
+            "input_sha256": digest(data),
+            "input_bytes": len(data),
+            "options_sha256": digest(json.dumps(OPTIONS, sort_keys=True).encode()),
+            "submitted_at": datetime.now(timezone.utc).isoformat(),
+            "state": "submission_unknown",
+        }
+        # A crash at any later point is conservatively an unknown submission.
+        save_json(self.output / "receipt.json", receipt)
+        task = await self.request_json(
+            "POST",
+            "/v1/convert/file/async",
+            files={"files": (input_path.name, data, "application/octet-stream")},
+            data=OPTIONS,
+        )
+        task_id = str(UUID(task["task_id"]))
+        receipt.update(task_id=task_id, state="submitted")
+        save_json(self.output / "receipt.json", receipt)
+        return receipt
+
+    async def collect(self, receipt, poll_interval=2):
+        task_id = str(UUID(receipt["task_id"]))
+        while True:
+            task = await self.request_json("GET", f"/v1/status/poll/{task_id}?wait=0")
+            require(task.get("task_id") == task_id, "Task identity mismatch.")
+            state = task.get("task_status")
+            require(
+                state in ("pending", "started", "success", "failure"),
+                "Unknown task state.",
+            )
+            if state == "failure":
+                raise ExampleError("Conversion task failed; inspect operator logs.")
+            if state == "success":
+                break
+            await asyncio.sleep(poll_interval)
+        result = await self.request_json("GET", f"/v1/result/{task_id}")
+        require(
+            result.get("num_converted") == 1
+            and result.get("num_succeeded") == 1
+            and result.get("num_partially_succeeded", 0) == 0
+            and result.get("num_failed") == 0,
+            "Conversion was incomplete or partially successful.",
+        )
+        documents = result.get("documents")
+        require(
+            isinstance(documents, list) and len(documents) == 1,
+            "Expected one document.",
+        )
+        document = documents[0]
+        require(
+            document.get("status") == "success" and not document.get("errors"),
+            "Document conversion failed.",
+        )
+        artifacts = document.get("artifacts", [])
+        require(
+            len(artifacts) == 2
+            and {a["artifact_type"] for a in artifacts} == {"markdown", "json"},
+            "Expected exactly Markdown and JSON artifacts.",
+        )
+        # Validate every URL before downloading any artifact. Never persist signatures.
+        identities = [
+            artifact_identity(a["uri"], self.storage_host, self.bucket, task_id)
+            for a in artifacts
+        ]
+        receipt["artifacts"] = [
+            dict(identity, artifact_type=a["artifact_type"])
+            for a, identity in zip(artifacts, identities)
+        ]
+        save_json(self.output / "receipt.json", receipt)
+        manifest = []
+        for artifact, identity in zip(artifacts, identities):
+            kind = artifact["artifact_type"]
+            filename = "document.md" if kind == "markdown" else "document.json"
+            entry = await self.download(artifact["uri"], filename, kind)
+            manifest.append(dict(identity, artifact_type=kind, **entry))
+        complete = dict(receipt, state="complete", artifacts=manifest)
+        save_json(self.output / "manifest.json", complete)
+        return complete
+
+    async def download(self, uri, filename, kind):
+        temporary = self.output / (filename + ".part")
+        size = 0
+        checksum = hashlib.sha256()
+        try:
+            # This client has no Docling or ingress credentials and follows no redirects.
+            async with self.storage.stream(
+                "GET", uri, headers={"Accept-Encoding": "identity"}
+            ) as res:
+                require(
+                    res.status_code == 200, f"Artifact returned HTTP {res.status_code}."
+                )
+                require(
+                    res.headers.get("content-encoding", "identity") == "identity",
+                    "Unexpected compressed artifact.",
+                )
+                length = res.headers.get("content-length")
+                require(
+                    length is None or 0 < int(length) <= MAX_ARTIFACT,
+                    "Artifact size is outside the limit.",
+                )
+                with temporary.open("wb") as stream:
+                    async for block in res.aiter_bytes():
+                        size += len(block)
+                        require(size <= MAX_ARTIFACT, "Artifact exceeds 20 MiB.")
+                        stream.write(block)
+                        checksum.update(block)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+                require(
+                    size > 0 and (length is None or size == int(length)),
+                    "Artifact is empty or truncated.",
+                )
+            # Readback validates local bytes, not an independently supplied remote digest.
+            content = temporary.read_bytes()
+            require(
+                digest(content) == checksum.hexdigest(),
+                "Local readback checksum mismatch.",
+            )
+            if kind == "json":
+                require(
+                    json.loads(content).get("schema_name") == "DoclingDocument",
+                    "Invalid Docling JSON artifact.",
+                )
+            else:
+                require(
+                    bool(content.decode("utf-8").strip()), "Empty Markdown artifact."
+                )
+            os.replace(temporary, self.output / filename)
+            return {"file": filename, "bytes": size, "sha256": checksum.hexdigest()}
+        finally:
+            temporary.unlink(missing_ok=True)
+
+
+def load_receipt(output, endpoint, endpoint_id, storage_host, bucket):
+    receipt = json.loads((output / "receipt.json").read_text())
+    require(
+        receipt.get("version") == 1
+        and receipt.get("endpoint") == endpoint
+        and receipt.get("endpoint_id") == endpoint_id
+        and receipt.get("storage_host") == storage_host
+        and receipt.get("bucket") == bucket,
+        "Receipt does not match the requested endpoint/storage configuration.",
+    )
+    require(
+        receipt.get("state") == "submitted" and "task_id" in receipt,
+        "Submission outcome unknown; reconcile manually. Do not resubmit automatically.",
+    )
+    return receipt
+
+
+def verify_complete(output, receipt):
+    manifest = json.loads((output / "manifest.json").read_text())
+    require(
+        manifest.get("task_id") == receipt["task_id"]
+        and manifest.get("state") == "complete",
+        "Invalid completion manifest.",
+    )
+    entries = manifest.get("artifacts", [])
+    require(
+        len(entries) == 2
+        and {e["file"] for e in entries} == {"document.md", "document.json"},
+        "Invalid manifest files.",
+    )
+    for entry in entries:
+        data = (output / entry["file"]).read_bytes()
+        require(
+            len(data) == entry["bytes"] and digest(data) == entry["sha256"],
+            "Saved artifact changed; completion cannot be verified.",
+        )
+    return manifest
+
+
+async def run(args):
+    endpoint = validate_endpoint(args.endpoint)
+    require(
+        re.fullmatch(r"[a-z0-9.-]+", args.storage_host) is not None,
+        "Invalid storage host.",
+    )
+    require(
+        re.fullmatch(r"[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]", args.bucket) is not None,
+        "Invalid bucket name.",
+    )
+    with locked_output(args.output, args.resume):
+        receipt = None
+        if args.resume:
+            receipt = load_receipt(
+                args.output, endpoint, args.endpoint_id, args.storage_host, args.bucket
+            )
+            if (args.output / "manifest.json").exists():
+                return verify_complete(args.output, receipt)
+        require(
+            bool(os.environ.get("NEBIUS_ENDPOINT_TOKEN"))
+            and bool(os.environ.get("DOCLING_API_KEY")),
+            "Set NEBIUS_ENDPOINT_TOKEN and DOCLING_API_KEY.",
+        )
+        headers = {
+            "Authorization": f"Bearer {os.environ['NEBIUS_ENDPOINT_TOKEN']}",
+            "X-Api-Key": os.environ["DOCLING_API_KEY"],
+        }
+        async with (
+            httpx.AsyncClient(
+                headers=headers, timeout=30, follow_redirects=False, trust_env=False
+            ) as api,
+            httpx.AsyncClient(
+                timeout=30, follow_redirects=False, trust_env=False
+            ) as storage,
+        ):
+            client = ConversionClient(
+                api, storage, endpoint, args.output, args.storage_host, args.bucket
+            )
+            if receipt is None:
+                await client.request_json("GET", "/ready")
+                receipt = await client.submit(args.file, args.endpoint_id)
+            return await client.collect(receipt)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--endpoint-id", required=True)
+    parser.add_argument("--storage-host", required=True)
+    parser.add_argument("--bucket", required=True)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="New directory on durable local storage; existing directory only with --resume.",
+    )
+    parser.add_argument("--file", type=Path)
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Observe an acknowledged task; never submit again.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=900,
+        help="Overall client deadline in seconds; does not cancel server work.",
+    )
+    args = parser.parse_args()
+    if not math.isfinite(args.timeout) or args.timeout <= 0:
+        parser.error("--timeout must be a positive finite number")
+    if (args.file is None) != args.resume:
+        parser.error("Use --file for a new submission, or --resume without --file")
+    try:
+        asyncio.run(asyncio.wait_for(run(args), timeout=args.timeout))
+    except ExampleError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    except asyncio.TimeoutError:
+        print(
+            "Client deadline reached; server work was not cancelled. Use the receipt to reconcile.",
+            file=sys.stderr,
+        )
+        return 1
+    except (OSError, ValueError, KeyError, TypeError, AttributeError, httpx.HTTPError):
+        print(
+            "Local I/O, transport or response validation failed. Preserve the receipt; do not blindly resubmit.",
+            file=sys.stderr,
+        )
+        return 1
+    print("Verified artifacts and manifest.json saved in the output directory.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/deploy-examples/nebius-serverless/docling-config.yaml
+++ b/docs/deploy-examples/nebius-serverless/docling-config.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+# Runtime credentials are injected through secret environment variables.
+eng_kind: local
+eng_loc_num_workers: 1
+eng_loc_share_models: true
+load_models_at_boot: true
+options_cache_size: 1
+enable_ui: false
+enable_management_endpoints: false
+show_version_info: false
+debug_error_details: false
+enable_remote_services: false
+allow_external_plugins: false
+allow_custom_vlm_config: false
+allow_custom_picture_description_config: false
+allow_custom_code_formula_config: false
+max_sources_per_request: 1
+max_num_pages: 20
+max_file_size: 10485760
+max_document_timeout: 300
+max_sync_wait: 30
+single_use_results: true
+result_removal_delay: 3600
+artifact_storage_enabled: true
+artifact_storage_backend: s3
+artifact_storage_verify_ssl: true
+artifact_storage_key_prefix: docling-example/
+artifact_storage_presign_ttl_seconds: 3600
+allowed_target_types:
+  - presigned_url

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,6 +6,7 @@ Choose the deployment option that best fits your setup.
 
 - **[Local GPU NVIDIA](#local-gpu-nvidia)**: For deploying the application locally on a machine with a supported NVIDIA GPU (using Docker Compose).
 - **[Local GPU AMD](#local-gpu-amd)**: For deploying the application locally on a machine with a supported AMD GPU (using Docker Compose).
+- **[Nebius Serverless](#nebius-serverless)**: A single-GPU Endpoint with asynchronous conversion and Object Storage results.
 - **[OpenShift](#openshift)**: For deploying the application on an OpenShift cluster, designed for cloud-native environments.
 
 ---
@@ -190,6 +191,14 @@ Docs:
     ```
 
 </details>
+
+## Nebius Serverless
+
+See the [Nebius Serverless Endpoint guide](./deploy-examples/nebius-serverless/README.md)
+and [configuration example](./deploy-examples/nebius-serverless/docling-config.yaml).
+The example serves a trusted client with one local worker; exported objects persist
+independently, while task status is lost if the server process is replaced.
+The guide records a validated L40S configuration and the limits of its live checks.
 
 ## OpenShift
 

--- a/tests/test_nebius_serverless_client.py
+++ b/tests/test_nebius_serverless_client.py
@@ -1,0 +1,403 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+"""Offline contract tests for the deployment example; no GPU/cloud credentials."""
+
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml
+
+EXAMPLE = Path(__file__).resolve().parents[1] / "docs/deploy-examples/nebius-serverless"
+spec = importlib.util.spec_from_file_location("nebius_example", EXAMPLE / "client.py")
+assert spec and spec.loader
+example = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(example)
+TASK = "74d3b87c-8246-4d1a-9f38-136346982f93"
+BASE = "https://endpoint.example.test"
+HOST = "storage.example.test"
+BUCKET = "example-results"
+PREFIX = f"docling-example/default/20260911/{TASK}/source"
+
+
+def result():
+    return {
+        "num_converted": 1,
+        "num_succeeded": 1,
+        "num_partially_succeeded": 0,
+        "num_failed": 0,
+        "documents": [
+            {
+                "status": "success",
+                "errors": [],
+                "artifacts": [
+                    {
+                        "artifact_type": "markdown",
+                        "uri": f"https://{HOST}/{BUCKET}/{PREFIX}/document.md?signature=secret",
+                    },
+                    {
+                        "artifact_type": "json",
+                        "uri": f"https://{HOST}/{BUCKET}/{PREFIX}/document.json?signature=secret",
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def storage(request):
+    assert "authorization" not in request.headers
+    assert "x-api-key" not in request.headers
+    body = (
+        b'{"schema_name":"DoclingDocument"}'
+        if request.url.path.endswith(".json")
+        else b"# Converted document\n"
+    )
+    return httpx.Response(200, content=body)
+
+
+async def exercise(tmp_path, api_handler, storage_handler=storage):
+    source = tmp_path / "input.html"
+    source.write_text("<h1>Example</h1>")
+    output = tmp_path / "output"
+    output.mkdir()
+    async with (
+        httpx.AsyncClient(transport=httpx.MockTransport(api_handler)) as api,
+        httpx.AsyncClient(transport=httpx.MockTransport(storage_handler)) as artifacts,
+    ):
+        client = example.ConversionClient(api, artifacts, BASE, output, HOST, BUCKET)
+        receipt = await client.submit(source, "endpoint-test")
+        return await client.collect(receipt, poll_interval=0)
+
+
+@pytest.mark.asyncio
+async def test_submit_poll_download_and_offline_resume(tmp_path):
+    calls = []
+    polls = iter(["pending", "started", "success"])
+
+    def api(request):
+        calls.append((request.method, request.url.path))
+        if request.method == "POST":
+            body = request.read()
+            for item in (
+                b'filename="input.html"',
+                b"presigned_url",
+                b"easyocr",
+                b'name="ocr_preset"',
+                b'"to_formats"',
+            ):
+                assert item in body
+            # Receipt must already exist before the request is dispatched.
+            assert (
+                json.loads((tmp_path / "output/receipt.json").read_text())["state"]
+                == "submission_unknown"
+            )
+            return httpx.Response(200, json={"task_id": TASK})
+        if "/poll/" in request.url.path:
+            return httpx.Response(
+                200, json={"task_id": TASK, "task_status": next(polls)}
+            )
+        return httpx.Response(200, json=result())
+
+    manifest = await exercise(tmp_path, api)
+    assert manifest["state"] == "complete"
+    assert len([c for c in calls if c[0] == "POST"]) == 1
+    output = tmp_path / "output"
+    receipt = example.load_receipt(output, BASE, "endpoint-test", HOST, BUCKET)
+    assert example.verify_complete(output, receipt) == manifest
+    assert "signature" not in (output / "receipt.json").read_text()
+    assert "signature" not in (output / "manifest.json").read_text()
+    (output / "document.md").write_text("changed")
+    with pytest.raises(example.ExampleError, match="changed"):
+        example.verify_complete(output, receipt)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure", ["timeout", "http500", "malformed", "wrong_id", "cancelled"]
+)
+async def test_unknown_submission_is_never_replayed(tmp_path, failure):
+    count = 0
+
+    def api(request):
+        nonlocal count
+        count += 1
+        if failure == "timeout":
+            raise httpx.ReadTimeout("contains a credential which must not be printed")
+        if failure == "cancelled":
+            raise asyncio.CancelledError
+        if failure == "http500":
+            return httpx.Response(500)
+        return httpx.Response(
+            200,
+            content=b"garbage"
+            if failure == "malformed"
+            else b'{"task_id":"../../bad"}',
+        )
+
+    with pytest.raises((example.ExampleError, ValueError, asyncio.CancelledError)):
+        await exercise(tmp_path, api)
+    assert count == 1
+    with pytest.raises(example.ExampleError, match="unknown"):
+        example.load_receipt(tmp_path / "output", BASE, "endpoint-test", HOST, BUCKET)
+    assert not (tmp_path / "output/manifest.json").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [401, 403, 404])
+async def test_poll_errors_do_not_replay_submission(tmp_path, status):
+    calls = []
+
+    def api(request):
+        calls.append(request.method)
+        return (
+            httpx.Response(200, json={"task_id": TASK})
+            if request.method == "POST"
+            else httpx.Response(status)
+        )
+
+    with pytest.raises(example.ExampleError, match=str(status)):
+        await exercise(tmp_path, api)
+    assert calls == ["POST", "GET"]
+    assert (
+        example.load_receipt(tmp_path / "output", BASE, "endpoint-test", HOST, BUCKET)[
+            "task_id"
+        ]
+        == TASK
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_uses_only_get(tmp_path):
+    seen = []
+
+    def api(request):
+        seen.append(request.method)
+        return httpx.Response(
+            200,
+            json={"task_id": TASK, "task_status": "success"}
+            if "/poll/" in request.url.path
+            else result(),
+        )
+
+    async with (
+        httpx.AsyncClient(transport=httpx.MockTransport(api)) as api_client,
+        httpx.AsyncClient(transport=httpx.MockTransport(storage)) as s3,
+    ):
+        client = example.ConversionClient(api_client, s3, BASE, tmp_path, HOST, BUCKET)
+        await client.collect({"task_id": TASK}, poll_interval=0)
+    assert seen == ["GET", "GET"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mode",
+    ["failure", "unknown_state", "partial", "document_failure", "missing_artifact"],
+)
+async def test_no_manifest_for_failed_or_partial_conversion(tmp_path, mode):
+    payload = result()
+    if mode == "partial":
+        payload["num_partially_succeeded"] = 1
+    if mode == "document_failure":
+        payload["documents"][0]["status"] = "failure"
+    if mode == "missing_artifact":
+        payload["documents"][0]["artifacts"].pop()
+
+    def api(request):
+        if request.method == "POST":
+            return httpx.Response(200, json={"task_id": TASK})
+        if "/poll/" in request.url.path:
+            state = mode if mode in ("failure", "unknown_state") else "success"
+            return httpx.Response(200, json={"task_id": TASK, "task_status": state})
+        return httpx.Response(200, json=payload)
+
+    with pytest.raises(example.ExampleError):
+        await exercise(tmp_path, api)
+    assert not (tmp_path / "output/manifest.json").exists()
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        f"http://{HOST}/{BUCKET}/{PREFIX}/a.md",
+        f"https://attacker.test/{BUCKET}/{PREFIX}/a.md",
+        f"https://{HOST}/other-bucket/{PREFIX}/a.md",
+        f"https://{HOST}/{BUCKET}/other-prefix/default/20260911/{TASK}/source/a.md",
+        f"https://{HOST}/{BUCKET}/{PREFIX}/%2E%2E",
+        f"https://user:password@{HOST}/{BUCKET}/{PREFIX}/a.md",
+        f"https://{HOST}:444/{BUCKET}/{PREFIX}/a.md",
+    ],
+)
+def test_artifact_url_scope(uri):
+    with pytest.raises(example.ExampleError):
+        example.artifact_identity(uri, HOST, BUCKET, TASK)
+
+
+def test_virtual_host_bucket_url():
+    assert example.artifact_identity(
+        f"https://{BUCKET}.{HOST}/{PREFIX}/a.md", HOST, BUCKET, TASK
+    ) == {"bucket": BUCKET, "key": f"{PREFIX}/a.md"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mode",
+    ["expired", "redirect", "oversized", "truncated", "corrupt_json", "compressed"],
+)
+async def test_artifact_failure_leaves_no_completion(tmp_path, mode, monkeypatch):
+    monkeypatch.setattr(example, "MAX_ARTIFACT", 64)
+
+    def api(request):
+        return httpx.Response(
+            200,
+            json={"task_id": TASK, "task_status": "success"}
+            if "/result/" not in request.url.path
+            else result(),
+        )
+
+    def bad_storage(request):
+        if mode == "expired":
+            return httpx.Response(403)
+        if mode == "redirect":
+            return httpx.Response(302, headers={"Location": "https://attacker.test"})
+        if mode == "oversized":
+            return httpx.Response(200, content=b"x" * 65)
+        if mode == "truncated":
+            return httpx.Response(
+                200, content=b"short", headers={"Content-Length": "20"}
+            )
+        if mode == "compressed":
+            return httpx.Response(
+                200, content=b"x", headers={"Content-Encoding": "identity, identity"}
+            )
+        return httpx.Response(200, content=b"not json")
+
+    with pytest.raises((example.ExampleError, ValueError, httpx.DecodingError)):
+        await exercise(tmp_path, api, bad_storage)
+    assert not (tmp_path / "output/manifest.json").exists()
+    assert not list((tmp_path / "output").glob("*.part"))
+
+
+@pytest.mark.asyncio
+async def test_deadline_preserves_acknowledged_task(tmp_path):
+    async def api(request):
+        if request.method == "POST":
+            return httpx.Response(200, json={"task_id": TASK})
+        await asyncio.sleep(10)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(exercise(tmp_path, api), timeout=0.05)
+    assert (
+        example.load_receipt(tmp_path / "output", BASE, "endpoint-test", HOST, BUCKET)[
+            "task_id"
+        ]
+        == TASK
+    )
+
+
+def test_single_writer_and_existing_output(tmp_path):
+    output = tmp_path / "result"
+    with example.locked_output(output, False):
+        with pytest.raises(example.ExampleError, match="Another client"):
+            with example.locked_output(output, True):
+                pytest.fail("Acquired duplicate lock")
+    with pytest.raises(FileExistsError):
+        with example.locked_output(output, False):
+            pytest.fail("Reused output")
+
+
+def test_config_keys_and_secret_overrides(monkeypatch):
+    from docling_serve.settings import DoclingServeSettings
+
+    data = yaml.safe_load((EXAMPLE / "docling-config.yaml").read_text())
+    assert not set(data) - set(DoclingServeSettings.model_fields)
+    monkeypatch.setenv(
+        "DOCLING_SERVE_CONFIG_FILE", str(EXAMPLE / "docling-config.yaml")
+    )
+    monkeypatch.setenv("DOCLING_SERVE_API_KEY", "test-only")
+    config = DoclingServeSettings()
+    assert config.api_key == "test-only"
+    assert config.scratch_path is None
+    assert config.max_file_size == example.MAX_INPUT
+    assert config.allowed_target_types == ["presigned_url"]
+
+
+@pytest.mark.asyncio
+async def test_transient_get_retries_without_reposting(tmp_path, monkeypatch):
+    calls = []
+
+    async def no_sleep(_):
+        pass
+
+    monkeypatch.setattr(example.asyncio, "sleep", no_sleep)
+
+    def api(request):
+        calls.append(request.method)
+        if request.method == "POST":
+            return httpx.Response(200, json={"task_id": TASK})
+        if len(calls) < 4:
+            return httpx.Response(503)
+        return httpx.Response(
+            200,
+            json={"task_id": TASK, "task_status": "success"}
+            if "/poll/" in request.url.path
+            else result(),
+        )
+
+    await exercise(tmp_path, api)
+    assert calls == ["POST", "GET", "GET", "GET", "GET"]
+
+
+@pytest.mark.asyncio
+async def test_input_limit_rejects_before_dispatch(tmp_path, monkeypatch):
+    monkeypatch.setattr(example, "MAX_INPUT", 1)
+
+    def api(request):
+        pytest.fail("Oversized input was submitted")
+
+    with pytest.raises(example.ExampleError, match="10 MiB"):
+        await exercise(tmp_path, api)
+    assert not (tmp_path / "output/receipt.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_control_response_is_bounded(tmp_path, monkeypatch):
+    monkeypatch.setattr(example, "MAX_JSON", 8)
+    with pytest.raises(example.ExampleError, match="byte limit"):
+        await exercise(tmp_path, lambda _: httpx.Response(200, content=b"x" * 9))
+    assert not (tmp_path / "output/manifest.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_download_stream_limit_and_cancellation(tmp_path, monkeypatch):
+    class Chunks(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b"1234"
+            yield b"5678"
+
+    monkeypatch.setattr(example, "MAX_ARTIFACT", 5)
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, stream=Chunks()))
+    ) as s3:
+        client = example.ConversionClient(None, s3, BASE, tmp_path, HOST, BUCKET)
+        with pytest.raises(example.ExampleError, match="exceeds"):
+            await client.download(f"https://{HOST}/file", "document.md", "markdown")
+    assert not (tmp_path / "document.md.part").exists()
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "http://example.test",
+        "https://example.test/v1",
+        "https://example.test?token=secret",
+        "https://user:secret@example.test",
+    ],
+)
+def test_endpoint_validation(endpoint):
+    with pytest.raises(example.ExampleError):
+        example.validate_endpoint(endpoint)


### PR DESCRIPTION
Add a Nebius Serverless Endpoint deployment guide, configuration, and asynchronous client for exporting Markdown and Docling JSON to private Object Storage. Link the example from the deployment index.

The client records a receipt before submission, never replays an ambiguous conversion POST, and supports resuming observation of an acknowledged task. Downloads are bounded and restricted to the expected storage host, bucket, and task prefix; a completion manifest is written only after both artifacts pass validation. The guide explains that exported objects survive independently while the local engine's task registry is lost on process replacement.

Validation:
- 40 client tests passed on Python 3.10 and 3.12; all six pre-commit hooks passed.
- 77 existing API/health/policy/form tests passed with session loop-scope overrides for the existing pytest-asyncio fixture mismatch.
- Real CPU app/OpenAPI and conversion tests passed with Moto S3 export, checksum readback, and injected export failure.
- Live validation on an L40S in `eu-north1` covered CUDA startup, native ingress/SecretStash/S3, text/table and scanned PDFs, separate read-only artifact verification, authentication, input limits, export failure, disconnect/deadline resume, stop/start, and confirmed resource cleanup. An invalid image was rejected before provisioning.

The live run established the CLI's text receipt formats and identified `ocr_preset=easyocr` as the effective multipart option; both are reflected in the example. Production capacity/ingress limits and full one-hour application URL expiry remain unmeasured. This adds no parser/runtime changes or package dependencies.
